### PR TITLE
Fix Wild Pokemon Level Increase in HGSS

### DIFF
--- a/src/com/dabomstew/pkrandom/romhandlers/Gen4RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen4RomHandler.java
@@ -1158,12 +1158,16 @@ public class Gen4RomHandler extends AbstractDSRomHandler {
                     // Get a single set of encounters...
                     // Write the encounters we get 3x for morning, day, night
                     EncounterSet grass = encounters.next();
+                    writeGrassEncounterLevelsHGSS(b, 8, grass.encounters);
                     writePokemonHGSS(b, 20, grass.encounters);
                     writePokemonHGSS(b, 44, grass.encounters);
                     writePokemonHGSS(b, 68, grass.encounters);
                 } else {
-                    for (int i = 0; i < 3; i++) {
-                        EncounterSet grass = encounters.next();
+                    EncounterSet grass = encounters.next();
+                    writeGrassEncounterLevelsHGSS(b, 8, grass.encounters);
+                    writePokemonHGSS(b, 20, grass.encounters);
+                    for (int i = 1; i < 3; i++) {
+                        grass = encounters.next();
                         writePokemonHGSS(b, 20 + i * 24, grass.encounters);
                     }
                 }
@@ -1205,6 +1209,14 @@ public class Gen4RomHandler extends AbstractDSRomHandler {
                 Encounter here = eIter.next();
                 writeWord(data, offset + i * 2, here.pokemon.number);
             }
+        }
+
+    }
+
+    private void writeGrassEncounterLevelsHGSS(byte[] data, int offset, List<Encounter> encounters) {
+        int enclength = encounters.size();
+        for (int i = 0; i < enclength; i++) {
+            data[offset + i] = (byte) encounters.get(i).level;
         }
 
     }


### PR DESCRIPTION
Fixes #1 

The reason why grass and cave encounters in HGSS were exclusively affected by this is because they have a separate "level table" at the start of its encounter files that is used for all times of day; this is even called out in a comment in `setEncounterHGSS`. However, we weren't actually *writing* to that table in the instance where the wild Pokemon's level is scaled.

This change writes the level from the encounter data to the appropriate place to update this "level table".