### PR TITLE
Randomize 1-character trainer names

### DIFF
--- a/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
@@ -3591,7 +3591,7 @@ public abstract class AbstractRomHandler implements RomHandler {
                     }
                     String changeTo = trainerName;
                     int ctl = intStrLen;
-                    if (pickFrom != null && pickFrom.size() > 0 && intStrLen > 1) {
+                    if (pickFrom != null && pickFrom.size() > 0 && intStrLen > 0) {
                         int innerTries = 0;
                         changeTo = pickFrom.get(this.cosmeticRandom.nextInt(pickFrom.size()));
                         ctl = this.internalStringLength(changeTo);


### PR DESCRIPTION
N's name isn't replaced during trainer name randomization due to the `intStrLen > 1` requirement