### PR TITLE
Copy TM/Tutor compatibility to cosmetic formes

### DIFF
--- a/src/com/dabomstew/pkrandom/Randomizer.java
+++ b/src/com/dabomstew/pkrandom/Randomizer.java
@@ -520,6 +520,12 @@ public class Randomizer {
             romHandler.fullHMCompatibility();
         }
 
+        // Copy TM/HM compatibility to cosmetic formes if it was changed at all
+        if (settings.getTmsHmsCompatibilityMod() != Settings.TMsHMsCompatibilityMod.UNCHANGED
+                || settings.isTmLevelUpMoveSanity()) {
+            romHandler.copyTMCompatibilityToCosmeticFormes();
+        }
+
         // Move Tutors (new 1.0.3)
         if (romHandler.hasMoveTutors()) {
             boolean noBrokenTutorMoves = settings.isBlockBrokenTutorMoves();
@@ -560,6 +566,12 @@ public class Randomizer {
 
             if (settings.isTutorLevelUpMoveSanity()) {
                 romHandler.ensureMoveTutorCompatSanity();
+            }
+
+            // Copy move tutor compatibility to cosmetic formes if it was changed at all
+            if (settings.getMoveTutorsCompatibilityMod() != Settings.MoveTutorsCompatibilityMod.UNCHANGED
+                    || settings.isTutorLevelUpMoveSanity()) {
+                romHandler.copyMoveTutorCompatibilityToCosmeticFormes();
             }
         }
 

--- a/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
@@ -3400,6 +3400,24 @@ public abstract class AbstractRomHandler implements RomHandler {
     }
 
     @Override
+    public void copyTMCompatibilityToCosmeticFormes() {
+        Map<Pokemon, boolean[]> compat = this.getTMHMCompatibility();
+
+        for (Map.Entry<Pokemon, boolean[]> compatEntry : compat.entrySet()) {
+            Pokemon pkmn = compatEntry.getKey();
+            boolean[] flags = compatEntry.getValue();
+            if (pkmn.actuallyCosmetic) {
+                boolean[] baseFlags = compat.get(pkmn.baseForme);
+                for (int i = 1; i < flags.length; i++) {
+                    flags[i] = baseFlags[i];
+                }
+            }
+        }
+
+        this.setTMHMCompatibility(compat);
+    }
+
+    @Override
     public void randomizeMoveTutorMoves(boolean noBroken, boolean preserveField, double goodDamagingProbability) {
         if (!this.hasMoveTutors()) {
             return;
@@ -3553,6 +3571,24 @@ public abstract class AbstractRomHandler implements RomHandler {
         }
         this.setMoveTutorCompatibility(compat);
 
+    }
+
+    @Override
+    public void copyMoveTutorCompatibilityToCosmeticFormes() {
+        Map<Pokemon, boolean[]> compat = this.getMoveTutorCompatibility();
+
+        for (Map.Entry<Pokemon, boolean[]> compatEntry : compat.entrySet()) {
+            Pokemon pkmn = compatEntry.getKey();
+            boolean[] flags = compatEntry.getValue();
+            if (pkmn.actuallyCosmetic) {
+                boolean[] baseFlags = compat.get(pkmn.baseForme);
+                for (int i = 1; i < flags.length; i++) {
+                    flags[i] = baseFlags[i];
+                }
+            }
+        }
+
+        this.setMoveTutorCompatibility(compat);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
@@ -334,6 +334,8 @@ public interface RomHandler {
 
     // Randomizer: move tutors
 
+    void copyTMCompatibilityToCosmeticFormes();
+
     boolean hasMoveTutors();
 
     List<Integer> getMoveTutorMoves();
@@ -355,6 +357,8 @@ public interface RomHandler {
     void ensureMoveTutorCompatSanity();
 
     // Randomizer: trainer names
+
+    void copyMoveTutorCompatibilityToCosmeticFormes();
 
     boolean canChangeTrainerText();
 


### PR DESCRIPTION
Fixes #117

I decided to put the TM/Tutor compatibility copying in its own method instead of including it in an existing method since TM/Tutor compatibility is modified in multiple different methods.