### PR TITLE
Added a few bad items for gen4

### DIFF
--- a/src/com/dabomstew/pkrandom/constants/Gen4Constants.java
+++ b/src/com/dabomstew/pkrandom/constants/Gen4Constants.java
@@ -469,6 +469,9 @@ public class Gen4Constants {
         nonBadItems.banRange(0x9F, 54); // berries DansGame
         nonBadItems.banRange(0x100, 4); // pokemon specific
         nonBadItems.banRange(0x104, 5); // contest scarves
+        nonBadItems.banRange(0x110, 2); // toxic orb, flame orb
+        nonBadItems.banRange(0x116, 2); // iron ball, lagging tail
+        nonBadItems.banSingles(0x120); // sticky barb
 
         regularShopItems = new ArrayList<>();
 


### PR DESCRIPTION
Added the following items to the "bad items" list for gen4:

Toxic Orb
Flame Orb
Iron Ball
Lagging Tail
Sticky Barb

While these items do have niche applications, I believe for the purposes of randomizer-related runs, these are pretty universally considered "bad".

This is part of an attempt to pare down some of the randomized items in gen4, specifically, where (especially in the context of ironmon runs) the abundance of new items over Gen3 dramatically reduces the chances of getting, for instance, healing items.

This was a pretty straightforward code change, so I feel pretty good about it overall.

I tested the following cases locally:

[ ] Open launcher, doesn't explode
[ ] Open launcher, open rom, load settings, patch Gen4 ROM, open ROM, nothing explodes
[ ] Open launcher, open rom, load settings, patch Gen3 ROM, open ROM, nothing explodes
[ ] Played a patched Gen4 ROM for ~30 minutes, nothing explodes
