### PR TITLE
Added feature to ban plates and incense from Gen4 random field items

### DIFF
--- a/src/com/dabomstew/pkrandom/Randomizer.java
+++ b/src/com/dabomstew/pkrandom/Randomizer.java
@@ -625,9 +625,9 @@ public class Randomizer {
         if (settings.getFieldItemsMod() == Settings.FieldItemsMod.SHUFFLE) {
             romHandler.shuffleFieldItems();
         } else if (settings.getFieldItemsMod() == Settings.FieldItemsMod.RANDOM) {
-            romHandler.randomizeFieldItems(settings.isBanBadRandomFieldItems(), false);
+            romHandler.randomizeFieldItems(settings.isBanBadRandomFieldItems(), settings.isBanRandomPlatesAndIncense(), false);
         } else if (settings.getFieldItemsMod() == Settings.FieldItemsMod.RANDOM_EVEN) {
-            romHandler.randomizeFieldItems(settings.isBanBadRandomFieldItems(), true);
+            romHandler.randomizeFieldItems(settings.isBanBadRandomFieldItems(), settings.isBanRandomPlatesAndIncense(), true);
         }
 
         if (settings.getShopItemsMod() == Settings.ShopItemsMod.SHUFFLE) {
@@ -636,7 +636,6 @@ public class Randomizer {
             romHandler.randomizeShopItems(settings.isBanBadRandomShopItems(), settings.isBanRegularShopItems(), settings.isBanOPShopItems(),
                     settings.isBalanceShopPrices(), settings.isGuaranteeEvolutionItems(), settings.isGuaranteeXItems());
         }
-
         
         // Shops
         if ((settings.getShopItemsMod() == Settings.ShopItemsMod.RANDOM || settings.getShopItemsMod() == Settings.ShopItemsMod.SHUFFLE)

--- a/src/com/dabomstew/pkrandom/Settings.java
+++ b/src/com/dabomstew/pkrandom/Settings.java
@@ -284,6 +284,7 @@ public class Settings {
 
     private FieldItemsMod fieldItemsMod = FieldItemsMod.UNCHANGED;
     private boolean banBadRandomFieldItems;
+    private boolean banRandomPlatesAndIncense;
 
     public enum ShopItemsMod {
         UNCHANGED, SHUFFLE, RANDOM
@@ -451,7 +452,8 @@ public class Settings {
 
         // 24 field items
         out.write(makeByteSelected(fieldItemsMod == FieldItemsMod.RANDOM, fieldItemsMod == FieldItemsMod.SHUFFLE,
-                fieldItemsMod == FieldItemsMod.UNCHANGED, banBadRandomFieldItems, fieldItemsMod == FieldItemsMod.RANDOM_EVEN));
+                fieldItemsMod == FieldItemsMod.UNCHANGED, banBadRandomFieldItems, fieldItemsMod == FieldItemsMod.RANDOM_EVEN,
+                banRandomPlatesAndIncense));
 
         // new 170
         // 25 move randomizers
@@ -725,6 +727,7 @@ public class Settings {
                 4   // RANDOM_EVEN
         ));
         settings.setBanBadRandomFieldItems(restoreState(data[24], 3));
+        settings.setBanRandomPlatesAndIncense(restoreState(data[24], 5));
 
         // new 170
         settings.setRandomizeMovePowers(restoreState(data[25], 0));
@@ -2053,9 +2056,16 @@ public class Settings {
         return banBadRandomFieldItems;
     }
 
-
     public void setBanBadRandomFieldItems(boolean banBadRandomFieldItems) {
         this.banBadRandomFieldItems = banBadRandomFieldItems;
+    }
+
+    public boolean isBanRandomPlatesAndIncense() {
+        return banRandomPlatesAndIncense;
+    }
+
+    public void setBanRandomPlatesAndIncense(boolean banRandomPlatesAndIncense) {
+        this.banRandomPlatesAndIncense = banRandomPlatesAndIncense;
     }
 
     public ShopItemsMod getShopItemsMod() {

--- a/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.form
+++ b/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.form
@@ -2958,6 +2958,17 @@
                       <toolTipText resource-bundle="com/dabomstew/pkrandom/newgui/Bundle" key="GUI.fiBanBadItemsCheckBox.toolTipText"/>
                     </properties>
                   </component>
+                  <component id="3f3fb" class="javax.swing.JCheckBox" binding="fiBanPlatesAndIncense">
+                    <constraints>
+                      <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <gridbag weightx="0.0" weighty="0.0"/>
+                    </constraints>
+                    <properties>
+                      <enabled value="false"/>
+                      <text value="Ban Plates and Incense"/>
+                      <toolTipText value="&lt;html&gt; Bans plates and incense, which are largely redundant with other items like TwistedSpoon aside from niche side-effects"/>
+                    </properties>
+                  </component>
                 </children>
               </grid>
               <hspacer id="36f9b">

--- a/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.java
+++ b/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.java
@@ -44,7 +44,6 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.List;
@@ -186,6 +185,7 @@ public class NewRandomizerGUI {
     private JRadioButton fiRandomRadioButton;
     private JRadioButton fiRandomEvenDistributionRadioButton;
     private JCheckBox fiBanBadItemsCheckBox;
+    private JCheckBox fiBanPlatesAndIncense;
     private JRadioButton shUnchangedRadioButton;
     private JRadioButton shShuffleRadioButton;
     private JRadioButton shRandomRadioButton;
@@ -1460,6 +1460,7 @@ public class NewRandomizerGUI {
         fiShuffleRadioButton.setSelected(settings.getFieldItemsMod() == Settings.FieldItemsMod.SHUFFLE);
         fiUnchangedRadioButton.setSelected(settings.getFieldItemsMod() == Settings.FieldItemsMod.UNCHANGED);
         fiBanBadItemsCheckBox.setSelected(settings.isBanBadRandomFieldItems());
+        fiBanPlatesAndIncense.setSelected(settings.isBanRandomPlatesAndIncense());
 
         shRandomRadioButton.setSelected(settings.getShopItemsMod() == Settings.ShopItemsMod.RANDOM);
         shShuffleRadioButton.setSelected(settings.getShopItemsMod() == Settings.ShopItemsMod.SHUFFLE);
@@ -1641,6 +1642,7 @@ public class NewRandomizerGUI {
 
         settings.setFieldItemsMod(fiUnchangedRadioButton.isSelected(), fiShuffleRadioButton.isSelected(), fiRandomRadioButton.isSelected(), fiRandomEvenDistributionRadioButton.isSelected());
         settings.setBanBadRandomFieldItems(fiBanBadItemsCheckBox.isSelected());
+        settings.setBanRandomPlatesAndIncense(fiBanPlatesAndIncense.isSelected());
 
         settings.setShopItemsMod(shUnchangedRadioButton.isSelected(), shShuffleRadioButton.isSelected(), shRandomRadioButton.isSelected());
 
@@ -2301,6 +2303,9 @@ public class NewRandomizerGUI {
         fiBanBadItemsCheckBox.setVisible(true);
         fiBanBadItemsCheckBox.setEnabled(false);
         fiBanBadItemsCheckBox.setSelected(false);
+        fiBanPlatesAndIncense.setVisible(false);
+        fiBanPlatesAndIncense.setEnabled(false);
+        fiBanPlatesAndIncense.setSelected(false);
         shUnchangedRadioButton.setVisible(true);
         shUnchangedRadioButton.setEnabled(false);
         shUnchangedRadioButton.setSelected(false);
@@ -2657,6 +2662,7 @@ public class NewRandomizerGUI {
             fiUnchangedRadioButton.setSelected(true);
             fiShuffleRadioButton.setEnabled(true);
             fiRandomRadioButton.setEnabled(true);
+            fiBanPlatesAndIncense.setVisible(pokemonGeneration == 4);
             fiRandomEvenDistributionRadioButton.setEnabled(true);
 
             shopItemsPanel.setVisible(romHandler.hasShopRandomization());
@@ -3204,12 +3210,16 @@ public class NewRandomizerGUI {
 
         if (fiRandomRadioButton.isSelected() && fiRandomRadioButton.isVisible() && fiRandomRadioButton.isEnabled()) {
             fiBanBadItemsCheckBox.setEnabled(true);
+            fiBanPlatesAndIncense.setEnabled(true);
         } else if (fiRandomEvenDistributionRadioButton.isSelected() && fiRandomEvenDistributionRadioButton.isVisible()
                 && fiRandomEvenDistributionRadioButton.isEnabled()) {
             fiBanBadItemsCheckBox.setEnabled(true);
+            fiBanPlatesAndIncense.setEnabled(true);
         } else {
             fiBanBadItemsCheckBox.setEnabled(false);
             fiBanBadItemsCheckBox.setSelected(false);
+            fiBanPlatesAndIncense.setEnabled(false);
+            fiBanPlatesAndIncense.setSelected(false);
         }
 
         if (shRandomRadioButton.isSelected() && shRandomRadioButton.isVisible() && shRandomRadioButton.isEnabled()) {

--- a/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
@@ -3867,6 +3867,11 @@ public abstract class AbstractRomHandler implements RomHandler {
     }
 
     @Override
+    public void banPlatesAndIncense(ItemList itemList) {
+        // Do nothing except in gen-specific logic
+    }
+
+    @Override
     public void randomizeWildHeldItems(boolean banBadItems) {
         List<Pokemon> pokemon = allPokemonInclFormesWithoutNull();
         ItemList possibleItems = banBadItems ? this.getNonBadItems() : this.getAllowedItems();
@@ -3989,8 +3994,12 @@ public abstract class AbstractRomHandler implements RomHandler {
     }
 
     @Override
-    public void randomizeFieldItems(boolean banBadItems, boolean distributeItemsControl) {
+    public void randomizeFieldItems(boolean banBadItems, boolean banPlatesAndIncense, boolean distributeItemsControl) {
         ItemList possibleItems = banBadItems ? this.getNonBadItems() : this.getAllowedItems();
+        if (banPlatesAndIncense) {
+            this.banPlatesAndIncense(possibleItems);
+        }
+
         List<Integer> currentItems = this.getRegularFieldItems();
         List<Integer> currentTMs = this.getCurrentFieldTMs();
         List<Integer> requiredTMs = this.getRequiredFieldTMs();

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen4RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen4RomHandler.java
@@ -3455,6 +3455,12 @@ public class Gen4RomHandler extends AbstractDSRomHandler {
     }
 
     @Override
+    public void banPlatesAndIncense(ItemList itemList) {
+        // ban plates and incense (298-320)
+        itemList.banRange(0x12A, 23);
+    }
+
+    @Override
     public List<Integer> getRegularShopItems() {
         return Gen4Constants.regularShopItems;
     }

--- a/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
@@ -412,6 +412,8 @@ public interface RomHandler {
 
     ItemList getNonBadItems();
 
+    void banPlatesAndIncense(ItemList itemList);
+
     List<Integer> getRegularShopItems();
 
     List<Integer> getOPShopItems();
@@ -448,7 +450,7 @@ public interface RomHandler {
 
     void shuffleFieldItems();
 
-    void randomizeFieldItems(boolean banBadItems, boolean distributeItemsControl);
+    void randomizeFieldItems(boolean banBadItems, boolean banPlatesAndIncense, boolean distributeItemsControl);
 
     // Trades
 


### PR DESCRIPTION
Added a Gen4-specific feature to optionally remove plates and incense from random field items.

This is part of an attempt to pare down some of the randomized items in gen4, specifically, where (especially in the context of ironmon runs) the abundance of new items over Gen3 dramatically reduces the chances of getting, for instance, healing items.

This one was a bit more involved than my other PR, but I feel like it was mostly pretty straightforward.  Nothing too advanced.  That said, the logic in Settings could use a critical eye.  Everything seems to be working, but I'm guessing that's the most likely vector for an unintentional bug to arise, as it deals with processes I may lack some understanding of.

I tested the following cases as part of this PR:

[ ] Run Launcher, open Gen4 ROM, open old settings, new checkbox is visible and unchecked
[ ] Run Launcher, open Gen4 ROM, open new settings (from my patch), new checkbox is visible and checked
[ ] Run launcher, open Gen4 ROM, click Items tab, checkbox is disabled and unchecked.  Click random or random (even distribution), checkbox is enabled and checked.
[ ] Run launcher, open Gen3 ROM, click Items tab, checkbox is not visible
[ ] Patch Gen4 rom with new feature, played for a few hours, did not encounter any of the banned items (not exactly a comprehensive test, but it's something)