### PR TITLE
Feature/cli randomizer

### DIFF
--- a/src/cli/CliRandomizer.java
+++ b/src/cli/CliRandomizer.java
@@ -54,9 +54,8 @@ public class CliRandomizer {
             }
             fis.close();
             // if we get here it means no rom handlers matched the ROM file
-            System.out.println("Couldn't identify a handler for your ROM file, please confirm it is valid and try again.");
+            System.err.println("Couldn't identify a handler for your ROM file, please confirm it is valid and try again.");
         }  catch (IOException ex) {
-            System.out.println("Error! Most likely couldn't read the supplied settings file.");
             ex.printStackTrace();
         }
         return false;
@@ -73,22 +72,22 @@ public class CliRandomizer {
         String settingsFilePath = args[0];
         String sourceRomFilePath = args[1];
         if (!new File(settingsFilePath).exists()) {
-            System.out.println("Error: could not read settings file");
+            System.err.println("Error: could not read settings file");
             System.out.println(CliRandomizer.usage());
             return 1;
         }
 
         // check that everything is readable/writable as appropriate
         if (!new File(sourceRomFilePath).exists()) {
-            System.out.println("Error: could not read source ROM file");
+            System.err.println("Error: could not read source ROM file");
             System.out.println(CliRandomizer.usage());
             return 1;
         }
 
         String outputRomFilePath = args[2];
         // java will return false for a non-existent file, have to check the parent directory
-        if (!new File(outputRomFilePath).getParentFile().canWrite()) {
-            System.out.println("Error: destination ROM path not writable");
+        if (!new File(outputRomFilePath).getAbsoluteFile().getParentFile().canWrite()) {
+            System.err.println("Error: destination ROM path not writable");
             System.out.println(CliRandomizer.usage());
             return 1;
         }
@@ -99,7 +98,7 @@ public class CliRandomizer {
                 outputRomFilePath
         );
         if (!processResult) {
-            System.out.println("Error: randomization failed");
+            System.err.println("Error: randomization failed");
             System.out.println(CliRandomizer.usage());
             return 1;
         }

--- a/src/cli/CliRandomizer.java
+++ b/src/cli/CliRandomizer.java
@@ -3,12 +3,13 @@ package cli;
 import com.dabomstew.pkrandom.FileFunctions;
 import com.dabomstew.pkrandom.RandomSource;
 import com.dabomstew.pkrandom.Settings;
+import com.dabomstew.pkrandom.Randomizer;
+import com.dabomstew.pkrandom.romhandlers.*;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import com.dabomstew.pkrandom.Randomizer;
-import com.dabomstew.pkrandom.romhandlers.*;
+import java.util.ResourceBundle;
 
 public class CliRandomizer {
 
@@ -18,6 +19,9 @@ public class CliRandomizer {
             String destinationRomFilePath
     ) {
 
+        // instantiate bundle so we can use consistent messaging where applicable
+        ResourceBundle bundle = java.util.ResourceBundle.getBundle("com/dabomstew/pkrandom/newgui/Bundle");
+        
         // borrowed directly from NewRandomizerGUI()
         RomHandler.Factory[] checkHandlers = new RomHandler.Factory[] {
                 new Gen1RomHandler.Factory(),
@@ -54,7 +58,7 @@ public class CliRandomizer {
             }
             fis.close();
             // if we get here it means no rom handlers matched the ROM file
-            System.err.println("Couldn't identify a handler for your ROM file, please confirm it is valid and try again.");
+            System.err.printf(bundle.getString("GUI.unsupportedRom"), romFileHandler.getName());
         }  catch (IOException ex) {
             ex.printStackTrace();
         }

--- a/src/cli/CliRandomizer.java
+++ b/src/cli/CliRandomizer.java
@@ -1,0 +1,101 @@
+package cli;
+
+import com.dabomstew.pkrandom.FileFunctions;
+import com.dabomstew.pkrandom.RandomSource;
+import com.dabomstew.pkrandom.Settings;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import com.dabomstew.pkrandom.Randomizer;
+import com.dabomstew.pkrandom.romhandlers.*;
+
+public class CliRandomizer {
+
+    private static boolean performDirectRandomization(
+            String settingsFilePath,
+            String sourceRomFilePath,
+            String destinationRomFilePath
+    ) {
+
+        RomHandler.Factory[] checkHandlers = new RomHandler.Factory[] { new Gen1RomHandler.Factory(), new Gen2RomHandler.Factory(),
+                new Gen3RomHandler.Factory(), new Gen4RomHandler.Factory(), new Gen5RomHandler.Factory(),
+                new Gen6RomHandler.Factory(), new Gen7RomHandler.Factory() };
+
+        try {
+            File fh = new File(settingsFilePath);
+            FileInputStream fis = new FileInputStream(fh);
+            Settings settings = Settings.read(fis);
+            settings.setCustomNames(FileFunctions.getCustomNames());
+
+            File romFileHandler = new File(sourceRomFilePath);
+            RomHandler romHandler = null;
+            for (RomHandler.Factory rhf : checkHandlers) {
+                if (rhf.isLoadable(romFileHandler.getAbsolutePath())) {
+                    romHandler = rhf.create(RandomSource.instance());
+                    romHandler.loadRom(romFileHandler.getAbsolutePath());
+                    Randomizer randomizer = new Randomizer(settings, romHandler, false);
+                    randomizer.randomize(destinationRomFilePath);
+                    break;
+                }
+            }
+            fis.close();
+            if (romHandler == null) {
+                System.out.println("Couldn't identify a handler for your ROM file, please confirm it is valid and try again.");
+            } else {
+                System.out.println("Randomized succesfully!");
+                // this is the only successful exit, everything else will return false at the end of the function
+                return true;
+            }
+        }  catch (IOException ex) {
+            System.out.println("Error! Most likely couldn't read the supplied settings file.");
+            ex.printStackTrace();
+        }
+        return false;
+    }
+
+    public static int invoke(String[] args) {
+        if (args.length < 3) {
+            System.out.println("Error: missing argument");
+            System.out.println(CliRandomizer.usage());
+            return 1;
+        }
+        // we know we have the right number of args
+        String settingsFilePath = args[0];
+        String sourceRomFilePath = args[1];
+        if (!new File(settingsFilePath).exists()) {
+            System.out.println("Error: could not read settings file");
+            System.out.println(CliRandomizer.usage());
+            return 1;
+        }
+
+        if (!new File(sourceRomFilePath).exists()) {
+            System.out.println("Error: could not read source ROM file");
+            System.out.println(CliRandomizer.usage());
+            return 1;
+        }
+
+        String outputRomFilePath = args[2];
+        if (!new File(outputRomFilePath).getParentFile().canWrite()) {
+            System.out.println("Error: destination ROM path not writable");
+            System.out.println(CliRandomizer.usage());
+            return 1;
+        }
+
+        boolean processResult = CliRandomizer.performDirectRandomization(
+                settingsFilePath,
+                sourceRomFilePath,
+                outputRomFilePath
+        );
+        if (!processResult) {
+            System.out.println("Error: randomization failed");
+            System.out.println(CliRandomizer.usage());
+            return 1;
+        }
+        return 0;
+    }
+
+    private static String usage() {
+        return "Usage: java -jar PokeRandoZX.jar cli <path to settings file> <path to source ROM> <path for new ROM>";
+    }
+}

--- a/src/cli/CliRandomizer.java
+++ b/src/cli/CliRandomizer.java
@@ -6,7 +6,6 @@ import com.dabomstew.pkrandom.Settings;
 import com.dabomstew.pkrandom.Randomizer;
 import com.dabomstew.pkrandom.romhandlers.*;
 
-import javax.swing.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -18,6 +17,74 @@ import java.util.ResourceBundle;
 public class CliRandomizer {
 
     private final static ResourceBundle bundle = java.util.ResourceBundle.getBundle("com/dabomstew/pkrandom/newgui/Bundle");
+
+    private static RomHandler getRomHandler(String romFilePath) {
+        File romFileHandler = new File(romFilePath);
+        // borrowed directly from NewRandomizerGUI()
+        RomHandler.Factory[] checkHandlers = new RomHandler.Factory[] {
+                new Gen1RomHandler.Factory(),
+                new Gen2RomHandler.Factory(),
+                new Gen3RomHandler.Factory(),
+                new Gen4RomHandler.Factory(),
+                new Gen5RomHandler.Factory(),
+                new Gen6RomHandler.Factory(),
+                new Gen7RomHandler.Factory()
+        };
+
+        for (RomHandler.Factory rhf : checkHandlers) {
+            if (rhf.isLoadable(romFileHandler.getAbsolutePath())) {
+                return rhf.create(RandomSource.instance());
+            }
+        }
+        return null;
+    }
+
+    private static Settings getValidatedSettings(String settingsFilePath) {
+        Settings settings;
+        try {
+            File fh = new File(settingsFilePath);
+            FileInputStream fis = new FileInputStream(fh);
+            settings = Settings.read(fis);
+            // taken from com.dabomstew.pkrandom.newgui.NewRandomizerGUI.saveROM, set distinctly from all other settings
+            settings.setCustomNames(FileFunctions.getCustomNames());
+            fis.close();
+        } catch (UnsupportedOperationException ex) {
+            ex.printStackTrace();
+            System.err.println(ex.getMessage());
+            return null;
+        } catch (IllegalArgumentException ex) {
+            ex.printStackTrace();
+            System.err.println(bundle.getString("GUI.invalidSettingsFile") + "%n");
+            return null;
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            System.err.println(bundle.getString("GUI.settingsLoadFailed") + "%n");
+            return null;
+        }
+        return settings;
+    }
+
+    private static boolean canSaveAsDirectory(String romFilePath) {
+        File romFileHandler = new File(romFilePath);
+        RomHandler romHandler = CliRandomizer.getRomHandler(romFilePath);
+        assert romHandler != null;
+        romHandler.loadRom(romFileHandler.getAbsolutePath());
+        return romHandler.generationOfPokemon() == 6 || romHandler.generationOfPokemon() == 7;
+    }
+
+    private static boolean isExtensionValid(String romFilePath) {
+        File romFileHandler = new File(romFilePath);
+        RomHandler romHandler = CliRandomizer.getRomHandler(romFilePath);
+        List<String> extensions = new ArrayList<>(Arrays.asList("sgb", "gbc", "gba", "nds", "cxi"));
+        assert romHandler != null;
+        extensions.remove(romHandler.getDefaultExtension());
+        File fh = FileFunctions.fixFilename(romFileHandler, romHandler.getDefaultExtension(), extensions);
+        if (romHandler instanceof AbstractDSRomHandler || romHandler instanceof Abstract3DSRomHandler) {
+            String currentFN = romHandler.loadedFilename();
+            return !currentFN.equals(fh.getAbsolutePath());
+        }
+        return true;
+    }
 
     private static boolean performDirectRandomization(
             String settingsFilePath,
@@ -33,74 +100,38 @@ public class CliRandomizer {
             String destinationRomFilePath,
             boolean saveAsDirectory
     ) {
-        // borrowed directly from NewRandomizerGUI()
-        RomHandler.Factory[] checkHandlers = new RomHandler.Factory[] {
-                new Gen1RomHandler.Factory(),
-                new Gen2RomHandler.Factory(),
-                new Gen3RomHandler.Factory(),
-                new Gen4RomHandler.Factory(),
-                new Gen5RomHandler.Factory(),
-                new Gen6RomHandler.Factory(),
-                new Gen7RomHandler.Factory()
-        };
-
-        Settings settings;
-        try {
-            File fh = new File(settingsFilePath);
-            FileInputStream fis = new FileInputStream(fh);
-            settings = Settings.read(fis);
-            // taken from com.dabomstew.pkrandom.newgui.NewRandomizerGUI.saveROM, set distinctly from all other settings
-            settings.setCustomNames(FileFunctions.getCustomNames());
-            fis.close();
-        } catch (UnsupportedOperationException ex) {
-            ex.printStackTrace();
-            System.err.println(ex.getMessage());
-            return false;
-        } catch (IllegalArgumentException ex) {
-            ex.printStackTrace();
-            System.err.println(bundle.getString("GUI.invalidSettingsFile") + "%n");
-            return false;
-        } catch (IOException ex) {
-            ex.printStackTrace();
-            System.err.println(bundle.getString("GUI.settingsLoadFailed") + "%n");
+        Settings settings = CliRandomizer.getValidatedSettings(settingsFilePath);
+        if (settings == null) {
             return false;
         }
 
         try {
             File romFileHandler = new File(sourceRomFilePath);
-            RomHandler romHandler;
-
-            for (RomHandler.Factory rhf : checkHandlers) {
-                if (rhf.isLoadable(romFileHandler.getAbsolutePath())) {
-                    romHandler = rhf.create(RandomSource.instance());
-                    romHandler.loadRom(romFileHandler.getAbsolutePath());
-                    if (saveAsDirectory && romHandler.generationOfPokemon() != 6 && romHandler.generationOfPokemon() != 7) {
-                        saveAsDirectory = false;
-                        System.out.println("WARNING: Saving as directory does not make sense for generations other than 6 and 7, ignoring...");
-                    }
-
-                    CliRandomizer.displaySettingsWarnings(settings, romHandler);
-
-                    List<String> extensions = new ArrayList<>(Arrays.asList("sgb", "gbc", "gba", "nds", "cxi"));
-                    extensions.remove(romHandler.getDefaultExtension());
-                    File fh = FileFunctions.fixFilename(romFileHandler, romHandler.getDefaultExtension(), extensions);
-                    if (romHandler instanceof AbstractDSRomHandler || romHandler instanceof Abstract3DSRomHandler) {
-                        String currentFN = romHandler.loadedFilename();
-                        if (currentFN.equals(fh.getAbsolutePath())) {
-                            System.err.println(bundle.getString("GUI.cantOverwriteDS") + "%n");
-                            return false;
-                        }
-                    }
-
-                    Randomizer randomizer = new Randomizer(settings, romHandler, saveAsDirectory);
-                    randomizer.randomize(destinationRomFilePath);
-                    System.out.println("Randomized succesfully!");
-                    // this is the only successful exit, everything else will return false at the end of the function
-                    return true;
-                }
+            RomHandler romHandler = CliRandomizer.getRomHandler(sourceRomFilePath);
+            if (romHandler == null) {
+                System.err.printf(bundle.getString("GUI.unsupportedRom") + "%n", romFileHandler.getName());
+                return false;
             }
-            // if we get here it means no rom handlers matched the ROM file
-            System.err.printf(bundle.getString("GUI.unsupportedRom") + "%n", romFileHandler.getName());
+
+            romHandler.loadRom(sourceRomFilePath);
+            CliRandomizer.displaySettingsWarnings(settings, romHandler);
+
+            boolean correctedSaveAsDirectory = saveAsDirectory && CliRandomizer.canSaveAsDirectory(sourceRomFilePath);
+            if (!correctedSaveAsDirectory && saveAsDirectory) {
+                // if save as dir was requested but it's not possible, warn the user
+                System.out.println("WARNING: Saving as directory does not make sense for generations other than 6 and 7, ignoring...");
+            }
+
+            if (!CliRandomizer.isExtensionValid(sourceRomFilePath)) {
+                System.err.println(bundle.getString("GUI.cantOverwriteDS") + "%n");
+                return false;
+            }
+
+            Randomizer randomizer = new Randomizer(settings, romHandler, correctedSaveAsDirectory);
+            randomizer.randomize(destinationRomFilePath);
+            System.out.println("Randomized succesfully!");
+            // this is the only successful exit, everything else will return false at the end of the function
+            return true;
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -126,8 +157,6 @@ public class CliRandomizer {
         List<String> allowedFlags = Arrays.asList("-i", "-o", "-s", "-d");
         for (int i = 0; i < args.length; i++) {
             if (allowedFlags.contains(args[i])) {
-                int flagValueIndex = i + 1;
-
                 switch(args[i]) {
                     case "-i":
                         sourceRomFilePath = args[i + 1];

--- a/src/com/dabomstew/pkrandom/cli/CliRandomizer.java
+++ b/src/com/dabomstew/pkrandom/cli/CliRandomizer.java
@@ -1,12 +1,11 @@
-package cli;
+package com.dabomstew.pkrandom.cli;
 
 import com.dabomstew.pkrandom.FileFunctions;
 import com.dabomstew.pkrandom.RandomSource;
-import com.dabomstew.pkrandom.Settings;
 import com.dabomstew.pkrandom.Randomizer;
+import com.dabomstew.pkrandom.Settings;
 import com.dabomstew.pkrandom.romhandlers.*;
 
-import javax.swing.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/src/com/dabomstew/pkrandom/cli/CliRandomizer.java
+++ b/src/com/dabomstew/pkrandom/cli/CliRandomizer.java
@@ -72,11 +72,11 @@ public class CliRandomizer {
 
                     CliRandomizer.displaySettingsWarnings(settings, romHandler);
 
+                    File fh = new File(destinationRomFilePath);
                     if (!saveAsDirectory) {
                         List<String> extensions = new ArrayList<>(Arrays.asList("sgb", "gbc", "gba", "nds", "cxi"));
                         extensions.remove(romHandler.getDefaultExtension());
 
-                        File fh = new File(destinationRomFilePath);
                         fh = FileFunctions.fixFilename(fh, romHandler.getDefaultExtension(), extensions);
                         if (romHandler instanceof AbstractDSRomHandler || romHandler instanceof Abstract3DSRomHandler) {
                             String currentFN = romHandler.loadedFilename();
@@ -89,7 +89,7 @@ public class CliRandomizer {
 
 
                     Randomizer randomizer = new Randomizer(settings, romHandler, saveAsDirectory);
-                    randomizer.randomize(destinationRomFilePath);
+                    randomizer.randomize(fh.getAbsolutePath());
                     System.out.println("Randomized succesfully!");
                     // this is the only successful exit, everything else will return false at the end of the function
                     return true;
@@ -119,6 +119,11 @@ public class CliRandomizer {
         String outputRomFilePath = null;
         boolean saveAsDirectory = false;
 
+        if (args.length > 0 && Arrays.asList(args).contains("--help")) {
+            printUsage();
+            return 0;
+        }
+
         List<String> allowedFlags = Arrays.asList("-i", "-o", "-s", "-d");
         for (int i = 0; i < args.length; i++) {
             if (allowedFlags.contains(args[i])) {
@@ -143,6 +148,7 @@ public class CliRandomizer {
 
         if (settingsFilePath == null || sourceRomFilePath == null || outputRomFilePath == null) {
             System.err.println("Missing required argument");
+            CliRandomizer.printUsage();
             return 1;
 
         }
@@ -183,6 +189,7 @@ public class CliRandomizer {
     }
 
     private static void printUsage() {
-        System.err.println("Usage: java -jar PokeRandoZX.jar cli -s <path to settings file> -i <path to source ROM> -o <path for new ROM> [-d save as directory]");
+        System.err.println("Usage: java -jar PokeRandoZX.jar cli -s <path to settings file> -i <path to source ROM> -o <path for new ROM> [-d]");
+        System.err.println("-d: Save 3DS game as directory (LayeredFS)");
     }
 }

--- a/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.java
+++ b/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.java
@@ -25,8 +25,8 @@ package com.dabomstew.pkrandom.newgui;
 /*--  along with this program. If not, see <http://www.gnu.org/licenses/>.  --*/
 /*----------------------------------------------------------------------------*/
 
-import cli.CliRandomizer;
 import com.dabomstew.pkrandom.*;
+import com.dabomstew.pkrandom.cli.CliRandomizer;
 import com.dabomstew.pkrandom.constants.GlobalConstants;
 import com.dabomstew.pkrandom.exceptions.EncryptedROMException;
 import com.dabomstew.pkrandom.exceptions.InvalidSupplementFilesException;

--- a/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.java
+++ b/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.java
@@ -25,6 +25,7 @@ package com.dabomstew.pkrandom.newgui;
 /*--  along with this program. If not, see <http://www.gnu.org/licenses/>.  --*/
 /*----------------------------------------------------------------------------*/
 
+import cli.CliRandomizer;
 import com.dabomstew.pkrandom.*;
 import com.dabomstew.pkrandom.constants.GlobalConstants;
 import com.dabomstew.pkrandom.exceptions.EncryptedROMException;
@@ -3480,24 +3481,33 @@ public class NewRandomizerGUI {
     }
 
     public static void main(String[] args) {
-        launcherInput = args.length > 0 ? args[0] : "";
-        if (launcherInput.equals("please-use-the-launcher")) usedLauncher = true;
-        SwingUtilities.invokeLater(() -> {
-            frame = new JFrame("NewRandomizerGUI");
-            try {
-                String lafName = javax.swing.UIManager.getSystemLookAndFeelClassName();
-                // NEW: Only set Native LaF on windows.
-                if (lafName.equalsIgnoreCase("com.sun.java.swing.plaf.windows.WindowsLookAndFeel")) {
-                    javax.swing.UIManager.setLookAndFeel(lafName);
+        String firstCliArg = args.length > 0 ? args[0] : "";
+        // invoke as CLI program
+        if (firstCliArg.equals("cli")) {
+            // snip the "cli" flag arg off the args array and invoke command
+            String[] commandArgs = Arrays.copyOfRange(args, 1, args.length);
+            int exitCode = CliRandomizer.invoke(commandArgs);
+            System.exit(exitCode);
+        } else {
+            launcherInput = firstCliArg;
+            if (launcherInput.equals("please-use-the-launcher")) usedLauncher = true;
+            SwingUtilities.invokeLater(() -> {
+                frame = new JFrame("NewRandomizerGUI");
+                try {
+                    String lafName = javax.swing.UIManager.getSystemLookAndFeelClassName();
+                    // NEW: Only set Native LaF on windows.
+                    if (lafName.equalsIgnoreCase("com.sun.java.swing.plaf.windows.WindowsLookAndFeel")) {
+                        javax.swing.UIManager.setLookAndFeel(lafName);
+                    }
+                } catch (ClassNotFoundException | InstantiationException | UnsupportedLookAndFeelException | IllegalAccessException ex) {
+                    java.util.logging.Logger.getLogger(NewRandomizerGUI.class.getName()).log(java.util.logging.Level.SEVERE, null,
+                            ex);
                 }
-            } catch (ClassNotFoundException | InstantiationException | UnsupportedLookAndFeelException | IllegalAccessException ex) {
-                java.util.logging.Logger.getLogger(NewRandomizerGUI.class.getName()).log(java.util.logging.Level.SEVERE, null,
-                        ex);
-            }
-            frame.setContentPane(new NewRandomizerGUI().mainPanel);
-            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-            frame.pack();
-            frame.setVisible(true);
-        });
+                frame.setContentPane(new NewRandomizerGUI().mainPanel);
+                frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+                frame.pack();
+                frame.setVisible(true);
+            });
+        }
     }
 }


### PR DESCRIPTION
Relating to this issue https://github.com/Ajarmar/universal-pokemon-randomizer-zx/issues/141

I'm not a Java developer by any means, so it's possible this will need some cleaning up. Additionally I'm not 100% sure if the code added for custom names is sufficient, it was borrowed from another place in the code but I can also see it's constructed a couple different ways and it wasn't immediately clear which was correct for this context. If it doesn't look right, I can look into it more.

I've tested this primarily with what I had on hand and am most familiar with, which is FireRed and it works nicely, but if there is a documented set of tests that should be run for contributions just let me know.

Also note, there seems to be an issue with the latest version of master loading the settings files I have on hand, so I've avoided merging that into this branch yet -- it seems independent of the changes made here.

Usage: `java -jar PokeRandoZX.jar cli <path to settings file> <path to source ROM> <path for new ROM>`