### PR TITLE
Add Sensible Items for Gen 3+

### DIFF
--- a/src/com/dabomstew/pkrandom/constants/Gen3Constants.java
+++ b/src/com/dabomstew/pkrandom/constants/Gen3Constants.java
@@ -220,13 +220,16 @@ public class Gen3Constants {
             softSand = 0x0cb, hardStone = 0x0cc, miracleSeed = 0x0cd, blackGlasses = 0x0ce, blackBelt = 0x0cf,
             magnet = 0x0d0, mysticWater = 0x0d1, sharpBeak = 0x0d2, poisonBarb = 0x0d3, neverMeltIce = 0x0d4,
             spellTag = 0x0d5, twistedSpoon = 0x0d6, charcoal = 0x0d7, dragonFang = 0x0d8, silkScarf = 0x0d9,
-            shellBell = 0x0db, seaIncense = 0x0dc, laxIncense = 0x0de;
+            shellBell = 0x0db, seaIncense = 0x0dc, laxIncense = 0x0dd;
+    // species-specific held items.
+    public static final int soulDew = 0x0bf, lightBall = 0x0ca, luckyPunch = 0x0de, metalPowder = 0x0df,
+            thickClub = 0x0e0, stick = 0x0e1;
 
-    public static final List<Integer> consumableHeldItems = Arrays.asList(
+    public static final List<Integer> consumableHeldItems = Collections.unmodifiableList(Arrays.asList(
             cheriBerry, chestoBerry, pechaBerry, rawstBerry, aspearBerry, leppaBerry, oranBerry, persimBerry,
             lumBerry, sitrusBerry, figyBerry, wikiBerry, magoBerry, aguavBerry, iapapaBerry, liechiBerry,
             ganlonBerry, salacBerry, petayaBerry, apicotBerry, lansatBerry, starfBerry, berryJuice, whiteHerb,
-            mentalHerb);
+            mentalHerb));
 
     public static final List<Integer> allHeldItems = setupAllHeldItems();
 
@@ -237,8 +240,65 @@ public class Gen3Constants {
                 mysticWater, sharpBeak, poisonBarb, neverMeltIce, spellTag, twistedSpoon, charcoal, dragonFang,
                 silkScarf, shellBell, seaIncense, laxIncense));
         list.addAll(consumableHeldItems);
-        return list;
+        return Collections.unmodifiableList(list);
     }
+
+    public static final List<Integer> generalPurposeConsumableItems = Collections.unmodifiableList(Arrays.asList(
+            cheriBerry, chestoBerry, pechaBerry, rawstBerry, aspearBerry, leppaBerry,
+            oranBerry, persimBerry, lumBerry, sitrusBerry, ganlonBerry, salacBerry,
+            // An NPC pokemon's nature is generated randomly with IVs during gameplay. Therefore, we do not include
+            // the flavor berries because, prior to Gen 7, they aren't worth the risk.
+            apicotBerry, lansatBerry, starfBerry, berryJuice, whiteHerb, mentalHerb
+    ));
+
+    public static final List<Integer> generalPurposeItems = Collections.unmodifiableList(Arrays.asList(
+            brightPowder, quickClaw, kingsRock, focusBand, scopeLens, leftovers, shellBell, laxIncense
+    ));
+
+    public static final Map<Type, List<Integer>> typeBoostingItems = initializeTypeBoostingItems();
+
+    private static Map<Type, List<Integer>> initializeTypeBoostingItems() {
+        Map<Type, List<Integer>> map = new HashMap<>();
+        map.put(Type.BUG, Arrays.asList(silverPowder));
+        map.put(Type.DARK, Arrays.asList(blackGlasses));
+        map.put(Type.DRAGON, Arrays.asList(dragonFang));
+        map.put(Type.ELECTRIC, Arrays.asList(magnet));
+        map.put(Type.FIGHTING, Arrays.asList(blackBelt));
+        map.put(Type.FIRE, Arrays.asList(charcoal));
+        map.put(Type.FLYING, Arrays.asList(sharpBeak));
+        map.put(Type.GHOST, Arrays.asList(spellTag));
+        map.put(Type.GRASS, Arrays.asList(miracleSeed));
+        map.put(Type.GROUND, Arrays.asList(softSand));
+        map.put(Type.ICE, Arrays.asList(neverMeltIce));
+        map.put(Type.NORMAL, Arrays.asList(silkScarf));
+        map.put(Type.POISON, Arrays.asList(poisonBarb));
+        map.put(Type.PSYCHIC, Arrays.asList(twistedSpoon));
+        map.put(Type.ROCK, Arrays.asList(hardStone));
+        map.put(Type.STEEL, Arrays.asList(metalCoat));
+        map.put(Type.WATER, Arrays.asList(mysticWater, seaIncense));
+        map.put(null, Collections.emptyList()); // ??? type
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Integer, List<Integer>> speciesBoostingItems = initializeSpeciesBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeSpeciesBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>();
+        map.put(Species.latias, Arrays.asList(soulDew));
+        map.put(Species.latios, Arrays.asList(soulDew));
+        map.put(Species.clamperl, Arrays.asList(deepSeaToothIndex, deepSeaScaleIndex));
+        map.put(Species.pikachu, Arrays.asList(lightBall));
+        map.put(Species.chansey, Arrays.asList(luckyPunch));
+        map.put(Species.ditto, Arrays.asList(metalPowder));
+        map.put(Species.cubone, Arrays.asList(thickClub));
+        map.put(Species.marowak, Arrays.asList(thickClub));
+        map.put(Species.farfetchd, Arrays.asList(stick));
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Set<Type> physicalTypes = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            Type.NORMAL, Type.FIGHTING, Type.POISON, Type.GROUND, Type.FLYING, Type.BUG,
+            Type.ROCK, Type.GHOST, Type.STEEL)));
 
     private static Type[] constructTypeTable() {
         Type[] table = new Type[256];

--- a/src/com/dabomstew/pkrandom/constants/Gen4Constants.java
+++ b/src/com/dabomstew/pkrandom/constants/Gen4Constants.java
@@ -101,7 +101,8 @@ public class Gen4Constants {
             // status effect berries
             cheriBerry = 0x95, chestoBerry = 0x96, pechaBerry = 0x97, rawstBerry = 0x98, aspearBerry = 0x99,
             leppaBerry = 0x9a, oranBerry = 0x9b, persimBerry = 0x9c, lumBerry = 0x9d, sitrusBerry = 0x9e,
-            // Restore 1/8 HP when below 50% but may cause confusion
+            // Restore 1/8 HP when below 50% but may cause confusion. In Gen 7, these heal 1/2 when
+            // below 25% (and still may cause confusion).
             figyBerry = 0x9f, wikiBerry = 0xa0, magoBerry = 0xa1, aguavBerry = 0xa2, iapapaBerry = 0xa3,
             // Reduce damage from supereffective damage
             occaBerry = 0xb8, passhoBerry = 0xb9, wacanBerry = 0xba, rindoBerry = 0xbb, yacheBerry = 0xbc,
@@ -124,15 +125,19 @@ public class Gen4Constants {
             spellTag = 0x0f7, twistedSpoon = 0x0f8, charcoal = 0x0f9, dragonFang = 0x0fa, silkScarf = 0x0fb,
             shellBell = 0x0fd, seaIncense = 0x0fe, laxIncense = 0x0ff, wideLens = 0x109, muscleBand = 0x10a,
             wiseGlasses = 0x10b, expertBelt = 0x10c, lightClay = 0x10d, lifeOrb = 0x10e, toxicOrb = 0x110,
-            flameOrb = 0x111, quickPowder = 0x112, zoomLens = 0x114, metronome = 0x115, ironBall = 0x116,
-            laggingTail = 0x117, destinyKnot = 0x118, blackSludge = 0x119, icyRock = 0x11a, smoothRock = 0x11b,
+            flameOrb = 0x111, zoomLens = 0x114, metronome = 0x115, ironBall = 0x116, laggingTail = 0x117,
+            destinyKnot = 0x118, blackSludge = 0x119, icyRock = 0x11a, smoothRock = 0x11b,
             heatRock = 0x11c, dampRock = 0x11d, gripClaw = 0x11e, choiceScarf = 0x11f, stickyBarb = 0x120,
             shedShell = 0x127, bigRoot = 0x128, choiceSpecs = 0x129, flamePlate = 0x12a, splashPlate = 0x12b,
             zapPlate = 0x12c, meadowPlate = 0x12d, iciclePlate = 0x12e, fistPlate = 0x12f, toxicPlate = 0x130,
             earthPlate = 0x131, skyPlate = 0x132, mindPlate = 0x133, insectPlate = 0x134, stonePlate = 0x135,
             spookyPlate = 0x136, dracoPlate = 0x137, dreadPlate = 0x138, ironPlate = 0x139, oddIncense = 0x13a,
-            rockIncense = 0x13b, fullIncense = 0x13c, waveIncense = 0x13d, roseIncense = 0x13e, pureIncense = 0x140,
+            rockIncense = 0x13b, fullIncense = 0x13c, waveIncense = 0x13d, roseIncense = 0x13e,
             razorClaw = 0x146, razorFang = 0x147;
+    // species-specific held items.
+    public static final int adamantOrb = 0x087, lustrousOrb = 0x088, soulDew = 0x0e1, deepSeaTooth = 0x0e2,
+            deepSeaScale = 0x0e3, lightBall = 0x0ec, luckyPunch = 0x100, metalPowder = 0x101, thickClub = 0x102,
+            stick = 0x103, quickPowder = 0x112;
 
     public static final List<Integer> consumableHeldItems = Arrays.asList(
             cheriBerry, chestoBerry, pechaBerry, rawstBerry, aspearBerry, leppaBerry, oranBerry, persimBerry,
@@ -150,14 +155,168 @@ public class Gen4Constants {
                 scopeLens, metalCoat, leftovers, softSand, hardStone, miracleSeed, blackGlasses, blackBelt, magnet,
                 mysticWater, sharpBeak, poisonBarb, neverMeltIce, spellTag, twistedSpoon, charcoal, dragonFang,
                 silkScarf, shellBell, seaIncense, laxIncense, wideLens, muscleBand, wiseGlasses, expertBelt, lightClay,
-                lifeOrb, toxicOrb, flameOrb, quickPowder, zoomLens, metronome, ironBall, laggingTail, destinyKnot,
+                lifeOrb, toxicOrb, flameOrb, zoomLens, metronome, ironBall, laggingTail, destinyKnot,
                 blackSludge, icyRock, smoothRock, heatRock, dampRock, gripClaw, choiceScarf, stickyBarb, shedShell,
                 bigRoot, choiceSpecs, flamePlate, splashPlate, zapPlate, meadowPlate, iciclePlate, fistPlate,
                 toxicPlate, earthPlate, skyPlate, mindPlate, insectPlate, stonePlate, spookyPlate, dracoPlate,
-                dreadPlate, ironPlate, oddIncense, rockIncense, fullIncense, waveIncense, roseIncense, pureIncense,
+                dreadPlate, ironPlate, oddIncense, rockIncense, fullIncense, waveIncense, roseIncense,
                 razorClaw, razorFang));
         list.addAll(consumableHeldItems);
         return list;
+    }
+
+    // Moves (their move index) affected by items
+    // https://bulbapedia.bulbagarden.net/wiki/List_of_moves
+    public static final int absorb = 71, aquaRing = 392, bind = 20, bounce = 340, clamp = 128, dig = 91, dive = 291,
+            drainPunch = 409, dreamEater = 138, facade = 263, fireSpin = 83, fling = 374, fly = 19,
+            gigaDrain = 202, hail = 258, ingrain = 275, leechLife = 141, leechSeed = 73, lightScreen = 113,
+            magmaStorm = 463, megaDrain = 72, outrage = 200, psychoShift = 375, rainDance = 240, razorWind = 13,
+            reflect = 115, sandstorm = 201, sandTomb = 328, skullBash = 130, skyAttack = 143, solarBeam = 76,
+            sunnyDay = 241, switcheroo = 415, trick = 271, trickRoom = 433, uproar = 253, whirlpool = 250, wrap = 35;
+
+    public static final List<Integer> generalPurposeConsumableItems = Collections.unmodifiableList(Arrays.asList(
+            cheriBerry, chestoBerry, pechaBerry, rawstBerry, aspearBerry, leppaBerry,
+            oranBerry, persimBerry, lumBerry, sitrusBerry, ganlonBerry, salacBerry,
+            // An NPC pokemon's nature is generated randomly with IVs during gameplay. Therefore, we do not include
+            // the flavor berries because, prior to Gen 7, they aren't worth the risk.
+            apicotBerry, lansatBerry, starfBerry, enigmaBerry, micleBerry, custapBerry,
+            jabocaBerry, rowapBerry, berryJuice, whiteHerb, mentalHerb, focusSash));
+
+    public static final List<Integer> generalPurposeItems = Collections.unmodifiableList(Arrays.asList(
+            brightPowder, quickClaw, kingsRock, focusBand, scopeLens, leftovers, shellBell, laxIncense,
+            wideLens, expertBelt, lifeOrb, zoomLens, destinyKnot, shedShell, razorClaw, razorFang));
+
+    public static final Map<Type, List<Integer>> typeBoostingItems = initializeTypeBoostingItems();
+
+    private static Map<Type, List<Integer>> initializeTypeBoostingItems() {
+        Map<Type, List<Integer>> map = new HashMap<>();
+        map.put(Type.BUG, Arrays.asList(silverPowder, insectPlate));
+        map.put(Type.DARK, Arrays.asList(blackGlasses, dreadPlate));
+        map.put(Type.DRAGON, Arrays.asList(dragonFang, dracoPlate));
+        map.put(Type.ELECTRIC, Arrays.asList(magnet, zapPlate));
+        map.put(Type.FIGHTING, Arrays.asList(blackBelt, fistPlate));
+        map.put(Type.FIRE, Arrays.asList(charcoal, flamePlate));
+        map.put(Type.FLYING, Arrays.asList(sharpBeak, skyPlate));
+        map.put(Type.GHOST, Arrays.asList(spellTag, spookyPlate));
+        map.put(Type.GRASS, Arrays.asList(miracleSeed, meadowPlate, roseIncense));
+        map.put(Type.GROUND, Arrays.asList(softSand, earthPlate));
+        map.put(Type.ICE, Arrays.asList(neverMeltIce, iciclePlate));
+        map.put(Type.NORMAL, Arrays.asList(silkScarf));
+        map.put(Type.POISON, Arrays.asList(poisonBarb, toxicPlate));
+        map.put(Type.PSYCHIC, Arrays.asList(twistedSpoon, mindPlate, oddIncense));
+        map.put(Type.ROCK, Arrays.asList(hardStone, stonePlate, rockIncense));
+        map.put(Type.STEEL, Arrays.asList(metalCoat, ironPlate));
+        map.put(Type.WATER, Arrays.asList(mysticWater, seaIncense, splashPlate, waveIncense));
+        map.put(null, Collections.emptyList()); // ??? type
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Integer, List<Integer>> moveBoostingItems = initializeMoveBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeMoveBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>();
+        map.put(bounce, Arrays.asList(powerHerb));
+        map.put(dig, Arrays.asList(powerHerb));
+        map.put(dive, Arrays.asList(powerHerb));
+        map.put(fly, Arrays.asList(powerHerb));
+        map.put(razorWind, Arrays.asList(powerHerb));
+        map.put(skullBash, Arrays.asList(powerHerb));
+        map.put(skyAttack, Arrays.asList(powerHerb));
+        map.put(solarBeam, Arrays.asList(powerHerb));
+
+        map.put(fling, Arrays.asList(toxicOrb, flameOrb, ironBall));
+
+        map.put(trick, Arrays.asList(toxicOrb, flameOrb, fullIncense, laggingTail));
+        map.put(switcheroo, Arrays.asList(toxicOrb, flameOrb, fullIncense, laggingTail));
+
+        map.put(trickRoom, Arrays.asList(ironBall));
+
+        map.put(facade, Arrays.asList(toxicOrb, flameOrb));
+
+        map.put(psychoShift, Arrays.asList(toxicOrb, flameOrb));
+
+        map.put(lightScreen, Arrays.asList(lightClay));
+        map.put(reflect, Arrays.asList(lightClay));
+
+        map.put(hail, Arrays.asList(icyRock));
+
+        map.put(sandstorm, Arrays.asList(smoothRock));
+
+        map.put(sunnyDay, Arrays.asList(heatRock));
+
+        map.put(rainDance, Arrays.asList(dampRock));
+
+        map.put(bind, Arrays.asList(gripClaw));
+        map.put(clamp, Arrays.asList(gripClaw));
+        map.put(fireSpin, Arrays.asList(gripClaw));
+        map.put(magmaStorm, Arrays.asList(gripClaw));
+        map.put(outrage, Arrays.asList(gripClaw));
+        map.put(sandTomb, Arrays.asList(gripClaw));
+        map.put(uproar, Arrays.asList(gripClaw));
+        map.put(whirlpool, Arrays.asList(gripClaw));
+        map.put(wrap, Arrays.asList(gripClaw));
+
+        map.put(absorb, Arrays.asList(bigRoot));
+        map.put(aquaRing, Arrays.asList(bigRoot));
+        map.put(drainPunch, Arrays.asList(bigRoot));
+        map.put(dreamEater, Arrays.asList(bigRoot));
+        map.put(gigaDrain, Arrays.asList(bigRoot));
+        map.put(ingrain, Arrays.asList(bigRoot));
+        map.put(leechLife, Arrays.asList(bigRoot));
+        map.put(leechSeed, Arrays.asList(bigRoot));
+        map.put(megaDrain, Arrays.asList(bigRoot));
+
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Type, Integer> weaknessReducingBerries = initializeWeaknessReducingBerries();
+
+    private static Map<Type, Integer> initializeWeaknessReducingBerries() {
+        Map<Type, Integer> map = new HashMap<>();
+        map.put(Type.FIRE, occaBerry);
+        map.put(Type.WATER, passhoBerry);
+        map.put(Type.ELECTRIC, wacanBerry);
+        map.put(Type.GRASS, rindoBerry);
+        map.put(Type.ICE, yacheBerry);
+        map.put(Type.FIGHTING, chopleBerry);
+        map.put(Type.POISON, kebiaBerry);
+        map.put(Type.GROUND, shucaBerry);
+        map.put(Type.FLYING, cobaBerry);
+        map.put(Type.PSYCHIC, payapaBerry);
+        map.put(Type.BUG, tangaBerry);
+        map.put(Type.ROCK, chartiBerry);
+        map.put(Type.GHOST, kasibBerry);
+        map.put(Type.DRAGON, habanBerry);
+        map.put(Type.DARK, colburBerry);
+        map.put(Type.STEEL, babiriBerry);
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Integer, List<Integer>> speciesBoostingItems = initializeSpeciesBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeSpeciesBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>();
+        map.put(Species.dialga, Arrays.asList(adamantOrb));
+        map.put(Species.palkia, Arrays.asList(lustrousOrb));
+        map.put(Species.latias, Arrays.asList(soulDew));
+        map.put(Species.latios, Arrays.asList(soulDew));
+        map.put(Species.clamperl, Arrays.asList(deepSeaTooth, deepSeaScale));
+        map.put(Species.pikachu, Arrays.asList(lightBall));
+        map.put(Species.chansey, Arrays.asList(luckyPunch));
+        map.put(Species.ditto, Arrays.asList(metalPowder, quickPowder));
+        map.put(Species.cubone, Arrays.asList(thickClub));
+        map.put(Species.marowak, Arrays.asList(thickClub));
+        map.put(Species.farfetchd, Arrays.asList(stick));
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Integer, List<Integer>> abilityBoostingItems = initializeAbilityBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeAbilityBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>();
+        map.put(Abilities.guts, Arrays.asList(flameOrb, toxicOrb));
+        map.put(Abilities.magicGuard, Arrays.asList(stickyBarb, lifeOrb));
+        return Collections.unmodifiableMap(map);
     }
 
     public static final Map<Integer,List<Integer>> abilityVariations = setupAbilityVariations();

--- a/src/com/dabomstew/pkrandom/constants/Gen5Constants.java
+++ b/src/com/dabomstew/pkrandom/constants/Gen5Constants.java
@@ -353,29 +353,95 @@ public class Gen5Constants {
     // New non-consumable held items with in-battle NPC effect (not specific to one pokemon family or one move)
     public static final int eviolite = 0x21a, floatStone = 0x21b, rockyHelmet = 0x21c, ringTarget = 0x21f,
             bindingBand = 0x220;
+    // New moves (their move index) affected by items
+    // https://bulbapedia.bulbagarden.net/wiki/List_of_moves
+    public static final int hornLeech = 532;
 
     public static final List<Integer> consumableHeldItems = setupAllConsumableItems();
 
     private static List<Integer> setupAllConsumableItems() {
-        List<Integer> list = new ArrayList<>();
-        list.addAll(Gen4Constants.consumableHeldItems);
+        List<Integer> list = new ArrayList<>(Gen4Constants.consumableHeldItems);
         list.addAll(Arrays.asList(airBalloon, redCard, absorbBulb, cellBattery, ejectButton, fireGem, waterGem,
                 electricGem, grassGem, iceGem, fightingGem, poisonGem, groundGem, flyingGem, psychicGem, bugGem,
                 rockGem, ghostGem, dragonGem, darkGem, steelGem, normalGem));
-        return list;
+        return Collections.unmodifiableList(list);
     }
 
     public static final List<Integer> allHeldItems = setupAllHeldItems();
 
     private static List<Integer> setupAllHeldItems() {
-        List<Integer> list = new ArrayList<>();
-        list.addAll(Gen4Constants.allHeldItems);
+        List<Integer> list = new ArrayList<>(Gen4Constants.allHeldItems);
         list.addAll(Arrays.asList(airBalloon, redCard, absorbBulb, cellBattery, ejectButton, fireGem, waterGem,
                 electricGem, grassGem, iceGem, fightingGem, poisonGem, groundGem, flyingGem, psychicGem, bugGem,
                 rockGem, ghostGem, dragonGem, darkGem, steelGem, normalGem));
         list.addAll(Arrays.asList(eviolite, floatStone, rockyHelmet, ringTarget, bindingBand));
-        return list;
+        return Collections.unmodifiableList(list);
     }
+
+    public static final List<Integer> generalPurposeConsumableItems = initializeGeneralPurposeConsumableItems();
+
+    private static List<Integer> initializeGeneralPurposeConsumableItems() {
+        List<Integer> list = new ArrayList<>(Gen4Constants.generalPurposeConsumableItems);
+        list.addAll(Arrays.asList(redCard, absorbBulb, cellBattery, ejectButton));
+        return Collections.unmodifiableList(list);
+    }
+
+    public static final List<Integer> generalPurposeItems = initializeGeneralPurposeItems();
+
+    private static List<Integer> initializeGeneralPurposeItems() {
+        List<Integer> list = new ArrayList<>(Gen4Constants.generalPurposeItems);
+        list.addAll(Arrays.asList(floatStone, rockyHelmet));
+        return Collections.unmodifiableList(list);
+    }
+
+    public static final Map<Type, Integer> consumableTypeBoostingItems = initializeConsumableTypeBoostingItems();
+
+    private static Map<Type, Integer> initializeConsumableTypeBoostingItems() {
+        Map<Type, Integer> map = new HashMap<>();
+        map.put(Type.FIRE, fireGem);
+        map.put(Type.WATER, waterGem);
+        map.put(Type.ELECTRIC, electricGem);
+        map.put(Type.GRASS, grassGem);
+        map.put(Type.ICE, iceGem);
+        map.put(Type.FIGHTING, fightingGem);
+        map.put(Type.POISON, poisonGem);
+        map.put(Type.GROUND, groundGem);
+        map.put(Type.FLYING, flyingGem);
+        map.put(Type.PSYCHIC, psychicGem);
+        map.put(Type.BUG, bugGem);
+        map.put(Type.ROCK, rockGem);
+        map.put(Type.GHOST, ghostGem);
+        map.put(Type.DRAGON, dragonGem);
+        map.put(Type.DARK, darkGem);
+        map.put(Type.STEEL, steelGem);
+        map.put(Type.NORMAL, normalGem);
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Integer, List<Integer>> moveBoostingItems = initializeMoveBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeMoveBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>(Gen4Constants.moveBoostingItems);
+        map.put(Gen4Constants.trick, Arrays.asList(Gen4Constants.toxicOrb, Gen4Constants.flameOrb, ringTarget));
+        map.put(Gen4Constants.switcheroo, Arrays.asList(Gen4Constants.toxicOrb, Gen4Constants.flameOrb, ringTarget));
+
+        map.put(Gen4Constants.bind, Arrays.asList(Gen4Constants.gripClaw, bindingBand));
+        map.put(Gen4Constants.clamp, Arrays.asList(Gen4Constants.gripClaw, bindingBand));
+        map.put(Gen4Constants.fireSpin, Arrays.asList(Gen4Constants.gripClaw, bindingBand));
+        map.put(Gen4Constants.magmaStorm, Arrays.asList(Gen4Constants.gripClaw, bindingBand));
+        map.put(Gen4Constants.sandTomb, Arrays.asList(Gen4Constants.gripClaw, bindingBand));
+        map.put(Gen4Constants.whirlpool, Arrays.asList(Gen4Constants.gripClaw, bindingBand));
+        map.put(Gen4Constants.wrap, Arrays.asList(Gen4Constants.gripClaw, bindingBand));
+
+        map.put(hornLeech, Arrays.asList(Gen4Constants.bigRoot));
+        return Collections.unmodifiableMap(map);
+    }
+
+    // None of these have new entries in Gen V.
+    public static final Map<Integer, List<Integer>> abilityBoostingItems = Gen4Constants.abilityBoostingItems;
+    public static final Map<Integer, List<Integer>> speciesBoostingItems = Gen4Constants.speciesBoostingItems;
+    public static final Map<Type, List<Integer>> typeBoostingItems = Gen4Constants.typeBoostingItems;
+    public static final Map<Type, Integer> weaknessReducingBerries = Gen4Constants.weaknessReducingBerries;
 
     private static Type[] constructTypeTable() {
         Type[] table = new Type[256];

--- a/src/com/dabomstew/pkrandom/constants/Gen6Constants.java
+++ b/src/com/dabomstew/pkrandom/constants/Gen6Constants.java
@@ -248,12 +248,15 @@ public class Gen6Constants {
             keeBerry = 0x2af, marangaBerry = 0x2b0, fairyGem = 0x02cb;
     // New non-consumable held items with in-battle NPC effect (not specific to one pokemon family or one move)
     public static final int assaultVest = 0x280, pixiePlate = 0x284, safetyGoggles = 0x28a;
+    // New moves (their move index) affected by items
+    // https://bulbapedia.bulbagarden.net/wiki/List_of_moves
+    public static final int drainingKiss = 577, electricTerrain = 604, grassyTerrain = 580, infestation = 611,
+            mistyTerrain = 581, oblivionWing = 613, parabolicCharge = 570;
 
     public static final List<Integer> consumableHeldItems = setupAllConsumableItems();
 
     private static List<Integer> setupAllConsumableItems() {
-        List<Integer> list = new ArrayList<>();
-        list.addAll(Gen5Constants.consumableHeldItems);
+        List<Integer> list = new ArrayList<>(Gen5Constants.consumableHeldItems);
         list.addAll(Arrays.asList(weaknessPolicy, luminousMoss, snowball, roseliBerry, keeBerry, marangaBerry, fairyGem));
         return list;
     }
@@ -261,12 +264,77 @@ public class Gen6Constants {
     public static final List<Integer> allHeldItems = setupAllHeldItems();
 
     private static List<Integer> setupAllHeldItems() {
-        List<Integer> list = new ArrayList<>();
-        list.addAll(Gen5Constants.allHeldItems);
+        List<Integer> list = new ArrayList<>(Gen5Constants.allHeldItems);
         list.addAll(Arrays.asList(weaknessPolicy, snowball, roseliBerry, keeBerry, marangaBerry, fairyGem));
         list.addAll(Arrays.asList(assaultVest, pixiePlate, safetyGoggles));
         return list;
     }
+
+    public static final List<Integer> generalPurposeConsumableItems = initializeGeneralPurposeConsumableItems();
+
+    private static List<Integer> initializeGeneralPurposeConsumableItems() {
+        List<Integer> list = new ArrayList<>(Gen5Constants.generalPurposeConsumableItems);
+        list.addAll(Arrays.asList(weaknessPolicy, luminousMoss, snowball, keeBerry, marangaBerry));
+        return Collections.unmodifiableList(list);
+    }
+
+    public static final List<Integer> generalPurposeItems = initializeGeneralPurposeItems();
+
+    private static List<Integer> initializeGeneralPurposeItems() {
+        List<Integer> list = new ArrayList<>(Gen5Constants.generalPurposeItems);
+        list.addAll(Arrays.asList(safetyGoggles));
+        return Collections.unmodifiableList(list);
+    }
+
+    public static final Map<Type, Integer> weaknessReducingBerries = initializeWeaknessReducingBerries();
+
+    private static Map<Type, Integer> initializeWeaknessReducingBerries() {
+        Map<Type, Integer> map = new HashMap<>(Gen5Constants.weaknessReducingBerries);
+        map.put(Type.FAIRY, roseliBerry);
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Type, Integer> consumableTypeBoostingItems = initializeConsumableTypeBoostingItems();
+
+    private static Map<Type, Integer> initializeConsumableTypeBoostingItems() {
+        Map<Type, Integer> map = new HashMap<>(Gen5Constants.consumableTypeBoostingItems);
+        map.put(Type.FAIRY, fairyGem);
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Type, List<Integer>> typeBoostingItems = initializeTypeBoostingItems();
+
+    private static Map<Type, List<Integer>> initializeTypeBoostingItems() {
+        Map<Type, List<Integer>> map = new HashMap<>(Gen5Constants.typeBoostingItems);
+        map.put(Type.FAIRY, Arrays.asList(pixiePlate));
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Integer, List<Integer>> moveBoostingItems = initializeMoveBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeMoveBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>(Gen5Constants.moveBoostingItems);
+        map.put(drainingKiss, Arrays.asList(Gen4Constants.bigRoot));
+        map.put(infestation, Arrays.asList(Gen4Constants.gripClaw, Gen5Constants.bindingBand));
+        map.put(oblivionWing, Arrays.asList(Gen4Constants.bigRoot));
+        map.put(parabolicCharge, Arrays.asList(Gen4Constants.bigRoot));
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Integer, List<Integer>> abilityBoostingItems = initializeAbilityBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeAbilityBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>(Gen5Constants.abilityBoostingItems);
+        // Weather from abilities changed in Gen VI, so these items become relevant.
+        map.put(Abilities.drizzle, Arrays.asList(Gen4Constants.dampRock));
+        map.put(Abilities.drought, Arrays.asList(Gen4Constants.heatRock));
+        map.put(Abilities.sandStream, Arrays.asList(Gen4Constants.smoothRock));
+        map.put(Abilities.snowWarning, Arrays.asList(Gen4Constants.icyRock));
+        return Collections.unmodifiableMap(map);
+    }
+
+    // No new species boosting items in Gen VI
+    public static final Map<Integer, List<Integer>> speciesBoostingItems = Gen5Constants.speciesBoostingItems;
 
     public static String getIngameTradesPrefix(int romType) {
         if (romType == Type_XY) {

--- a/src/com/dabomstew/pkrandom/constants/Gen7Constants.java
+++ b/src/com/dabomstew/pkrandom/constants/Gen7Constants.java
@@ -199,12 +199,14 @@ public class Gen7Constants {
             mistySeed = 0x373, grassySeed = 0x374;
     // New non-consumable held items with in-battle NPC effect (not specific to one pokemon family or one move)
     public static final int terrainExtender = 0x36F, protectivePads = 0x370;
+    // New moves (their move index) affected by items
+    // https://bulbapedia.bulbagarden.net/wiki/List_of_moves
+    public static final int psychicTerrain = 678, strengthSap = 668;
 
     public static final List<Integer> consumableHeldItems = setupAllConsumableItems();
 
     private static List<Integer> setupAllConsumableItems() {
-        List<Integer> list = new ArrayList<>();
-        list.addAll(Gen6Constants.consumableHeldItems);
+        List<Integer> list = new ArrayList<>(Gen6Constants.consumableHeldItems);
         list.addAll(Arrays.asList(adrenalineOrb, electricSeed, psychicSeed, mistySeed, grassySeed));
         return list;
     }
@@ -214,12 +216,68 @@ public class Gen7Constants {
     private static List<Integer> setupAllHeldItems() {
         // We intentionally do not include Z Crystals in this list. Adding Z-Crystals to random trainers should
         // probably require its own setting if desired.
-        List<Integer> list = new ArrayList<>();
-        list.addAll(Gen6Constants.allHeldItems);
+        List<Integer> list = new ArrayList<>(Gen6Constants.allHeldItems);
         list.addAll(Arrays.asList(adrenalineOrb, electricSeed, psychicSeed, mistySeed, grassySeed));
         list.addAll(Arrays.asList(terrainExtender, protectivePads));
         return list;
     }
+
+    public static final List<Integer> generalPurposeConsumableItems = initializeGeneralPurposeConsumableItems();
+
+    private static List<Integer> initializeGeneralPurposeConsumableItems() {
+        List<Integer> list = new ArrayList<>(Gen6Constants.generalPurposeConsumableItems);
+        // These berries are worth the risk of causing confusion because they heal for half max HP.
+        list.addAll(Arrays.asList(Gen4Constants.figyBerry, Gen4Constants.wikiBerry, Gen4Constants.magoBerry,
+                Gen4Constants.aguavBerry, Gen4Constants.iapapaBerry, adrenalineOrb));
+        return Collections.unmodifiableList(list);
+    }
+
+    public static final List<Integer> generalPurposeItems = initializeGeneralPurposeItems();
+
+    private static List<Integer> initializeGeneralPurposeItems() {
+        List<Integer> list = new ArrayList<>(Gen6Constants.generalPurposeItems);
+        list.addAll(Arrays.asList(protectivePads));
+        return Collections.unmodifiableList(list);
+    }
+
+    public static final Map<Integer, List<Integer>> moveBoostingItems = initializeMoveBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeMoveBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>(Gen6Constants.moveBoostingItems);
+        map.put(Gen6Constants.electricTerrain, Arrays.asList(terrainExtender));
+        map.put(Gen6Constants.grassyTerrain, Arrays.asList(terrainExtender));
+        map.put(Gen6Constants.mistyTerrain, Arrays.asList(terrainExtender));
+        map.put(psychicTerrain, Arrays.asList(terrainExtender));
+        map.put(strengthSap, Arrays.asList(Gen4Constants.bigRoot));
+        return Collections.unmodifiableMap(map);
+    }
+    public static final Map<Integer, List<Integer>> abilityBoostingItems = initializeAbilityBoostingItems();
+
+    private static Map<Integer, List<Integer>> initializeAbilityBoostingItems() {
+        Map<Integer, List<Integer>> map = new HashMap<>(Gen6Constants.abilityBoostingItems);
+        map.put(Abilities.electricSurge, Arrays.asList(terrainExtender));
+        map.put(Abilities.grassySurge, Arrays.asList(terrainExtender));
+        map.put(Abilities.mistySurge, Arrays.asList(terrainExtender));
+        map.put(Abilities.psychicSurge, Arrays.asList(terrainExtender));
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<Integer, Integer> consumableAbilityBoostingItems = initializeConsumableAbilityBoostingItems();
+
+    private static Map<Integer, Integer> initializeConsumableAbilityBoostingItems() {
+        Map<Integer, Integer> map = new HashMap<>();
+        map.put(Abilities.electricSurge, electricSeed);
+        map.put(Abilities.grassySurge, grassySeed);
+        map.put(Abilities.mistySurge, mistySeed);
+        map.put(Abilities.psychicSurge, psychicSeed);
+        return Collections.unmodifiableMap(map);
+    }
+
+    // None of these have new entries in Gen VII.
+    public static final Map<Type, Integer> consumableTypeBoostingItems = Gen6Constants.consumableTypeBoostingItems;
+    public static final Map<Integer, List<Integer>> speciesBoostingItems = Gen6Constants.speciesBoostingItems;
+    public static final Map<Type, List<Integer>> typeBoostingItems = Gen6Constants.typeBoostingItems;
+    public static final Map<Type, Integer> weaknessReducingBerries = Gen6Constants.weaknessReducingBerries;
 
     public static boolean isZCrystal(int itemIndex) {
         // From https://bulbapedia.bulbagarden.net/wiki/List_of_items_by_index_number_(Generation_VII)

--- a/src/com/dabomstew/pkrandom/newgui/Bundle.properties
+++ b/src/com/dabomstew/pkrandom/newgui/Bundle.properties
@@ -594,7 +594,7 @@ GUI.tpRegularTrainersItemsCheckBox.toolTipText=<html>Check this to add or replac
 GUI.tpConsumableItemsOnlyCheckBox.text=Consumable Only
 GUI.tpConsumableItemsOnlyCheckBox.tooltip=<html>Items will be chosen randomly from all single-use held items that a Pokemon can eat/use on its own.<br />This is mostly berries, with a few other items like Focus Sash and White Herb.</html>
 GUI.tpSensibleItemsCheckBox.text=Sensible Items
-GUI.tpSensibleItemsCheckBox.tooltip=<html><b>Not implemented yet.</b><br />Items will be chosen randomly from a subset of the held items that "make sense" for a given Pokemon.<br />For example, Silk Scarf won't be an option for a given Pokemon unless it knows at least one normal move.<br />Another example is that a Yache berry will only be an option on Pokemon that are weak or double weak to ice.</html>
+GUI.tpSensibleItemsCheckBox.tooltip=<html>Items will be chosen randomly from a subset of the held items that "make sense" for a given Pokemon.<br />For example, Silk Scarf won't be an option for a given Pokemon unless it knows at least one damaging normal move.<br />Another example is that a Yache berry will only be an option on Pokemon that are weak or double weak to ice.</html>
 GUI.tpHighestLevelGetsItemCheckBox.text=Highest Level Only
 GUI.tpHighestLevelGetsItemCheckBox.tooltip=<html>If this option is selected, a held item will be given only to a trainer's highest level Pokemon (or one of them, if there are multiple at that level).<br />If this is unchecked, all of a Trainer's Pokemon will be given items.</html>
 

--- a/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.java
+++ b/src/com/dabomstew/pkrandom/newgui/NewRandomizerGUI.java
@@ -3079,7 +3079,7 @@ public class NewRandomizerGUI {
         if (tpBossTrainersItemsCheckBox.isSelected() || tpImportantTrainersItemsCheckBox.isSelected() ||
                 tpRegularTrainersItemsCheckBox.isSelected()) {
             tpConsumableItemsOnlyCheckBox.setEnabled(true);
-            tpSensibleItemsCheckBox.setEnabled(false); // not implemented yet
+            tpSensibleItemsCheckBox.setEnabled(true);
             tpHighestLevelGetsItemCheckBox.setEnabled(true);
         } else {
             tpConsumableItemsOnlyCheckBox.setEnabled(false);

--- a/src/com/dabomstew/pkrandom/pokemon/Effectiveness.java
+++ b/src/com/dabomstew/pkrandom/pokemon/Effectiveness.java
@@ -1,0 +1,115 @@
+package com.dabomstew.pkrandom.pokemon;
+
+/*----------------------------------------------------------------------------*/
+/*--  Effectiveness.java - represents a type's effectiveness and the        --*/
+/*--  results of applying super effectiveness and resistance                --*/
+/*--                                                                        --*/
+/*--  Part of "Universal Pokemon Randomizer ZX" by the UPR-ZX team          --*/
+/*--  Originally part of "Universal Pokemon Randomizer" by Dabomstew        --*/
+/*--  Pokemon and any associated names and the like are                     --*/
+/*--  trademark and (C) Nintendo 1996-2020.                                 --*/
+/*--                                                                        --*/
+/*--  The custom code written here is licensed under the terms of the GPL:  --*/
+/*--                                                                        --*/
+/*--  This program is free software: you can redistribute it and/or modify  --*/
+/*--  it under the terms of the GNU General Public License as published by  --*/
+/*--  the Free Software Foundation, either version 3 of the License, or     --*/
+/*--  (at your option) any later version.                                   --*/
+/*--                                                                        --*/
+/*--  This program is distributed in the hope that it will be useful,       --*/
+/*--  but WITHOUT ANY WARRANTY; without even the implied warranty of        --*/
+/*--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          --*/
+/*--  GNU General Public License for more details.                          --*/
+/*--                                                                        --*/
+/*--  You should have received a copy of the GNU General Public License     --*/
+/*--  along with this program. If not, see <http://www.gnu.org/licenses/>.  --*/
+/*----------------------------------------------------------------------------*/
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public enum Effectiveness {
+    ZERO, HALF, NEUTRAL, DOUBLE, QUARTER, QUADRUPLE;
+
+    // Returns a map where the key is a type and the value is the effectiveness against
+    // a pokemon with the two types in a given gen. It does not account for abilities.
+    public static Map<Type, Effectiveness> against(Type primaryType, Type secondaryType, int gen) {
+        if (gen >= 2 && gen <= 5) {
+            return against(primaryType, secondaryType, gen2Through5Table, Type.GEN2THROUGH5);
+        }
+        if (gen >= 6) {
+            return against(primaryType, secondaryType, gen6PlusTable, Type.GEN6PLUS);
+        }
+        return null;
+    }
+
+    private static Map<Type, Effectiveness> against(Type primaryType, Type secondaryType, Effectiveness[][] effectivenesses, List<Type> allTypes) {
+        Map<Type, Effectiveness> result = new HashMap<>();
+        for(Type type : allTypes) {
+            Effectiveness effect = effectivenesses[type.ordinal()][primaryType.ordinal()];
+            if (secondaryType != null) {
+                effect = effect.combine(effectivenesses[type.ordinal()][secondaryType.ordinal()]);
+            }
+            result.put(type, effect);
+        }
+        return result;
+    }
+
+    // Attacking type is the row, Defending type is the column. This corresponds to the ordinal of types.
+    private static final Effectiveness[][] gen2Through5Table = {
+        /*            NORMAL,FIGHTING, FLYING,   GRASS ,   WATER,   FIRE ,   ROCK , GROUND,  PSYCHIC,   BUG  ,  DRAGON,ELECTRIC,   GHOST , POISON,   ICE  ,  STEEL ,  DARK  */
+        /*NORMAL */ {NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    ZERO, NEUTRAL, NEUTRAL,    HALF, NEUTRAL},
+        /*FIGHTING*/{ DOUBLE, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL,    ZERO,    HALF,  DOUBLE,  DOUBLE,  DOUBLE},
+        /*FLYING */ {NEUTRAL,  DOUBLE, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL},
+        /*GRASS  */ {NEUTRAL, NEUTRAL,    HALF,    HALF,  DOUBLE,    HALF,  DOUBLE,  DOUBLE, NEUTRAL,    HALF,    HALF, NEUTRAL, NEUTRAL,    HALF, NEUTRAL,    HALF, NEUTRAL},
+        /*WATER  */ {NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF,  DOUBLE,  DOUBLE,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL},
+        /*FIRE   */ {NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE,    HALF,    HALF,    HALF, NEUTRAL, NEUTRAL,  DOUBLE,    HALF, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE,  DOUBLE, NEUTRAL},
+        /*ROCK   */ {NEUTRAL,    HALF,  DOUBLE, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL,    HALF, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE,    HALF, NEUTRAL},
+        /*GROUND */ {NEUTRAL, NEUTRAL,    ZERO,    HALF, NEUTRAL,  DOUBLE,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL,  DOUBLE, NEUTRAL,  DOUBLE, NEUTRAL,  DOUBLE, NEUTRAL},
+        /*PSYCHIC*/ {NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL,    HALF,    ZERO},
+        /*BUG    */ {NEUTRAL,    HALF,    HALF,  DOUBLE, NEUTRAL,    HALF, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL,    HALF,  DOUBLE},
+        /*DRAGON */ {NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL},
+        /*ELECTRIC*/{NEUTRAL, NEUTRAL,  DOUBLE,    HALF,  DOUBLE, NEUTRAL, NEUTRAL,    ZERO, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL},
+        /*GHOST  */ {   ZERO, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF,    HALF},
+        /*POISON */ {NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL,    ZERO, NEUTRAL},
+        /*ICE    */ {NEUTRAL, NEUTRAL,  DOUBLE,  DOUBLE,    HALF,    HALF, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL},
+        /*STEEL  */ {NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL,  DOUBLE,    HALF, NEUTRAL},
+        /*DARK   */ {NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF,    HALF},
+    };
+    private static final Effectiveness[][] gen6PlusTable = {
+        /*            NORMAL,FIGHTING, FLYING,   GRASS ,   WATER,   FIRE ,   ROCK , GROUND,  PSYCHIC,   BUG  ,  DRAGON,ELECTRIC,   GHOST , POISON,   ICE  ,  STEEL ,  DARK  , FAIRY */
+        /*NORMAL */ {NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    ZERO, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL},
+        /*FIGHTING*/{ DOUBLE, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL,    ZERO,    HALF,  DOUBLE,  DOUBLE,  DOUBLE,    HALF},
+        /*FLYING */ {NEUTRAL,  DOUBLE, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL},
+        /*GRASS  */ {NEUTRAL, NEUTRAL,    HALF,    HALF,  DOUBLE,    HALF,  DOUBLE,  DOUBLE, NEUTRAL,    HALF,    HALF, NEUTRAL, NEUTRAL,    HALF, NEUTRAL,    HALF, NEUTRAL, NEUTRAL},
+        /*WATER  */ {NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF,  DOUBLE,  DOUBLE,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL},
+        /*FIRE   */ {NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE,    HALF,    HALF,    HALF, NEUTRAL, NEUTRAL,  DOUBLE,    HALF, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE,  DOUBLE, NEUTRAL, NEUTRAL},
+        /*ROCK   */ {NEUTRAL,    HALF,  DOUBLE, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL,    HALF, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE,    HALF, NEUTRAL, NEUTRAL},
+        /*GROUND */ {NEUTRAL, NEUTRAL,    ZERO,    HALF, NEUTRAL,  DOUBLE,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL,  DOUBLE, NEUTRAL,  DOUBLE, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL},
+        /*PSYCHIC*/ {NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL,    HALF,    ZERO, NEUTRAL},
+        /*BUG    */ {NEUTRAL,    HALF,    HALF,  DOUBLE, NEUTRAL,    HALF, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL,    HALF,  DOUBLE,    HALF},
+        /*DRAGON */ {NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL,    ZERO},
+        /*ELECTRIC*/{NEUTRAL, NEUTRAL,  DOUBLE,    HALF,  DOUBLE, NEUTRAL, NEUTRAL,    ZERO, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL},
+        /*GHOST  */ {   ZERO, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL},
+        /*POISON */ {NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL,    ZERO, NEUTRAL,  DOUBLE},
+        /*ICE    */ {NEUTRAL, NEUTRAL,  DOUBLE,  DOUBLE,    HALF,    HALF, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF, NEUTRAL, NEUTRAL},
+        /*STEEL  */ {NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL,  DOUBLE,    HALF, NEUTRAL,  DOUBLE},
+        /*DARK   */ {NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,    HALF,    HALF},
+        /*FAIRY  */ {NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL, NEUTRAL,    HALF, NEUTRAL, NEUTRAL, NEUTRAL, NEUTRAL,  DOUBLE, NEUTRAL, NEUTRAL,    HALF, NEUTRAL,    HALF,  DOUBLE, NEUTRAL},
+    };
+
+    private Effectiveness combine(Effectiveness other) {
+        return combineTable[this.ordinal()][other.ordinal()];
+    }
+
+    // Allows easier calculation of combining a single type attacking a double typed pokemon.
+    // The rows and columns are the ordinals of Effectiveness (but only the first 4, as we don't need to
+    // combine 3 or more type considerations).
+    private static final Effectiveness[][] combineTable = {
+        {ZERO,    ZERO,    ZERO,      ZERO},
+        {ZERO, QUARTER,    HALF,   NEUTRAL},
+        {ZERO,    HALF, NEUTRAL,    DOUBLE},
+        {ZERO, NEUTRAL,  DOUBLE, QUADRUPLE},
+    };
+}

--- a/src/com/dabomstew/pkrandom/pokemon/Type.java
+++ b/src/com/dabomstew/pkrandom/pokemon/Type.java
@@ -49,6 +49,9 @@ public enum Type {
     private static final List<Type> VALUES = Collections.unmodifiableList(Arrays.asList(values()));
     private static final int SIZE = VALUES.size();
 
+    public static final List<Type> GEN2THROUGH5 = Collections.unmodifiableList(Arrays.asList(values()).subList(0, DARK.ordinal()+1));
+    public static final List<Type> GEN6PLUS = Collections.unmodifiableList(Arrays.asList(values()).subList(0, FAIRY.ordinal()+1));
+
     public static Type randomType(Random random) {
         return VALUES.get(random.nextInt(SIZE));
     }

--- a/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
@@ -1930,6 +1930,9 @@ public abstract class AbstractRomHandler implements RomHandler {
         boolean giveToImportantPokemon = settings.isRandomizeHeldItemsForBossTrainerPokemon();
         boolean giveToRegularPokemon = settings.isRandomizeHeldItemsForBossTrainerPokemon();
         boolean highestLevelOnly = settings.isHighestLevelGetsItemsForTrainers();
+
+        List<Move> moves = this.getMoves();
+        Map<Integer, List<MoveLearnt>> movesets = this.getMovesLearnt();
         List<Trainer> currentTrainers = this.getTrainers();
         for (Trainer t : currentTrainers) {
             if (!giveToRegularPokemon && (!t.isImportant() && !t.isBoss())) {
@@ -1954,17 +1957,17 @@ public abstract class AbstractRomHandler implements RomHandler {
                 if (highestLevelPoke == null) {
                     continue; // should never happen - trainer had zero pokes
                 }
-                randomizeHeldItem(highestLevelPoke, settings);
+                randomizeHeldItem(highestLevelPoke, settings, moves, movesets);
             } else {
                 for (TrainerPokemon tp : t.pokemon) {
-                    randomizeHeldItem(tp, settings);
+                    randomizeHeldItem(tp, settings, moves, movesets);
                 }
             }
         }
         this.setTrainers(currentTrainers, false);
     }
 
-    private void randomizeHeldItem(TrainerPokemon tp, Settings settings) {
+    private void randomizeHeldItem(TrainerPokemon tp, Settings settings, List<Move> moves, Map<Integer, List<MoveLearnt>> movesets) {
         boolean sensibleItemsOnly = settings.isSensibleItemsOnlyForTrainers();
         boolean consumableItemsOnly = settings.isConsumableItemsOnlyForTrainers();
         boolean swapMegaEvolutions = settings.isSwapTrainerMegaEvos();
@@ -1976,7 +1979,7 @@ public abstract class AbstractRomHandler implements RomHandler {
         }
         List<Integer> toChooseFrom;
         if (sensibleItemsOnly) {
-            toChooseFrom = getSensibleHeldItemsFor(tp, consumableItemsOnly);
+            toChooseFrom = getSensibleHeldItemsFor(tp, consumableItemsOnly, moves, movesets);
         } else if (consumableItemsOnly) {
             toChooseFrom = getAllConsumableHeldItems();
         } else {
@@ -6167,7 +6170,7 @@ public abstract class AbstractRomHandler implements RomHandler {
     }
 
     @Override
-    public List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly) {
+    public List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly, List<Move> moves, Map<Integer, List<MoveLearnt>> movesets) {
         return Arrays.asList(0);
     }
 

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen3RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen3RomHandler.java
@@ -3418,4 +3418,42 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
     public List<Integer> getAllConsumableHeldItems() {
         return Gen3Constants.consumableHeldItems;
     }
+
+    @Override
+    public List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly, List<Move> moves, Map<Integer, List<MoveLearnt>> movesets) {
+        List<Integer> items = new ArrayList<>();
+        items.addAll(Gen3Constants.generalPurposeConsumableItems);
+        if (!consumableOnly) {
+            items.addAll(Gen3Constants.generalPurposeItems);
+        }
+        int[] pokeMoves = RomFunctions.getMovesAtLevel(tp.pokemon.number, movesets, tp.level);
+        for (int moveIdx : pokeMoves) {
+            Move move = moves.get(moveIdx);
+            if (move == null) {
+                continue;
+            }
+            if (Gen3Constants.physicalTypes.contains(move.type) && move.power > 0) {
+                items.add(Gen3Constants.liechiBerry);
+                if (!consumableOnly) {
+                    items.addAll(Gen3Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen3Constants.choiceBand);
+                }
+            }
+            if (!Gen3Constants.physicalTypes.contains(move.type) && move.power > 0) {
+                items.add(Gen3Constants.petayaBerry);
+                if (!consumableOnly) {
+                    items.addAll(Gen3Constants.typeBoostingItems.get(move.type));
+                }
+            }
+        }
+        if (!consumableOnly) {
+            List<Integer> speciesItems = Gen3Constants.speciesBoostingItems.get(tp.pokemon.number);
+            if (speciesItems != null) {
+                for (int i = 0; i < 6; i++) {  // Increase the likelihood of using species specific items.
+                    items.addAll(speciesItems);
+                }
+            }
+        }
+        return items;
+    }
 }

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen4RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen4RomHandler.java
@@ -34,13 +34,11 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.dabomstew.pkrandom.*;
-import com.dabomstew.pkrandom.constants.Species;
+import com.dabomstew.pkrandom.constants.*;
 import com.dabomstew.pkrandom.pokemon.*;
 import thenewpoketext.PokeTextData;
 import thenewpoketext.TextToPoke;
 
-import com.dabomstew.pkrandom.constants.Gen4Constants;
-import com.dabomstew.pkrandom.constants.GlobalConstants;
 import com.dabomstew.pkrandom.exceptions.RandomizerIOException;
 import com.dabomstew.pkrandom.newnds.NARCArchive;
 
@@ -4298,5 +4296,75 @@ public class Gen4RomHandler extends AbstractDSRomHandler {
     @Override
     public List<Integer> getAllHeldItems() {
         return Gen4Constants.allHeldItems;
+    }
+
+    @Override
+    public List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly, List<Move> moves, Map<Integer, List<MoveLearnt>> movesets) {
+        List<Integer> items = new ArrayList<>();
+        items.addAll(Gen4Constants.generalPurposeConsumableItems);
+        int frequencyBoostCount = 6; // Make some very good items more common, but not too common
+        if (!consumableOnly) {
+            frequencyBoostCount = 8; // bigger to account for larger item pool.
+            items.addAll(Gen4Constants.generalPurposeItems);
+        }
+        int[] pokeMoves = RomFunctions.getMovesAtLevel(tp.pokemon.number, movesets, tp.level);
+        for (int moveIdx : pokeMoves) {
+            Move move = moves.get(moveIdx);
+            if (move == null) {
+                continue;
+            }
+            if (move.category == MoveCategory.PHYSICAL) {
+                items.add(Gen4Constants.liechiBerry);
+                if (!consumableOnly) {
+                    items.addAll(Gen4Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen4Constants.choiceBand);
+                    items.add(Gen4Constants.muscleBand);
+                }
+            }
+            if (move.category == MoveCategory.SPECIAL) {
+                items.add(Gen4Constants.petayaBerry);
+                if (!consumableOnly) {
+                    items.addAll(Gen4Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen4Constants.wiseGlasses);
+                    items.add(Gen4Constants.choiceSpecs);
+                }
+            }
+            if (!consumableOnly && Gen4Constants.moveBoostingItems.containsKey(moveIdx)) {
+                items.addAll(Gen4Constants.moveBoostingItems.get(moveIdx));
+            }
+        }
+        Map<Type, Effectiveness> byType = Effectiveness.against(tp.pokemon.primaryType, tp.pokemon.secondaryType, 4);
+        for(Map.Entry<Type, Effectiveness> entry : byType.entrySet()) {
+            Integer berry = Gen4Constants.weaknessReducingBerries.get(entry.getKey());
+            if (entry.getValue() == Effectiveness.DOUBLE) {
+                items.add(berry);
+            } else if (entry.getValue() == Effectiveness.QUADRUPLE) {
+                for (int i = 0; i < frequencyBoostCount; i++) {
+                    items.add(berry);
+                }
+            }
+        }
+        if (byType.get(Type.NORMAL) == Effectiveness.NEUTRAL) {
+            items.add(Gen4Constants.chilanBerry);
+        }
+        if (tp.ability == Abilities.levitate) {
+            items.removeAll(Arrays.asList(Gen4Constants.shucaBerry));
+        }
+
+        if (!consumableOnly) {
+            if (Gen4Constants.abilityBoostingItems.containsKey(tp.ability)) {
+                items.addAll(Gen4Constants.abilityBoostingItems.get(tp.ability));
+            }
+            if (tp.pokemon.primaryType == Type.POISON || tp.pokemon.secondaryType == Type.POISON) {
+                items.add(Gen4Constants.blackSludge);
+            }
+            List<Integer> speciesItems = Gen4Constants.speciesBoostingItems.get(tp.pokemon.number);
+            if (speciesItems != null) {
+                for (int i = 0; i < frequencyBoostCount; i++) {
+                    items.addAll(speciesItems);
+                }
+            }
+        }
+        return items;
     }
 }

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen5RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen5RomHandler.java
@@ -36,12 +36,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.dabomstew.pkrandom.*;
-import com.dabomstew.pkrandom.constants.Species;
+import com.dabomstew.pkrandom.constants.*;
 import com.dabomstew.pkrandom.pokemon.*;
 import pptxt.PPTxtHandler;
 
-import com.dabomstew.pkrandom.constants.Gen5Constants;
-import com.dabomstew.pkrandom.constants.GlobalConstants;
 import com.dabomstew.pkrandom.exceptions.RandomizerIOException;
 import com.dabomstew.pkrandom.newnds.NARCArchive;
 import compressors.DSDecmp;
@@ -3465,5 +3463,84 @@ public class Gen5RomHandler extends AbstractDSRomHandler {
     @Override
     public List<Integer> getAllConsumableHeldItems() {
         return Gen5Constants.consumableHeldItems;
+    }
+
+    @Override
+    public List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly, List<Move> moves, Map<Integer, List<MoveLearnt>> movesets) {
+        List<Integer> items = new ArrayList<>();
+        items.addAll(Gen5Constants.generalPurposeConsumableItems);
+        int frequencyBoostCount = 6; // Make some very good items more common, but not too common
+        if (!consumableOnly) {
+            frequencyBoostCount = 8; // bigger to account for larger item pool.
+            items.addAll(Gen5Constants.generalPurposeItems);
+        }
+        int[] pokeMoves = RomFunctions.getMovesAtLevel(tp.pokemon.number, movesets, tp.level);
+        for (int moveIdx : pokeMoves) {
+            Move move = moves.get(moveIdx);
+            if (move == null) {
+                continue;
+            }
+            if (move.category == MoveCategory.PHYSICAL) {
+                items.add(Gen4Constants.liechiBerry);
+                items.add(Gen5Constants.consumableTypeBoostingItems.get(move.type));
+                if (!consumableOnly) {
+                    items.addAll(Gen5Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen4Constants.choiceBand);
+                    items.add(Gen4Constants.muscleBand);
+                }
+            }
+            if (move.category == MoveCategory.SPECIAL) {
+                items.add(Gen4Constants.petayaBerry);
+                items.add(Gen5Constants.consumableTypeBoostingItems.get(move.type));
+                if (!consumableOnly) {
+                    items.addAll(Gen5Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen4Constants.wiseGlasses);
+                    items.add(Gen4Constants.choiceSpecs);
+                }
+            }
+            if (!consumableOnly && Gen5Constants.moveBoostingItems.containsKey(moveIdx)) {
+                items.addAll(Gen5Constants.moveBoostingItems.get(moveIdx));
+            }
+        }
+        Map<Type, Effectiveness> byType = Effectiveness.against(tp.pokemon.primaryType, tp.pokemon.secondaryType, 5);
+        for(Map.Entry<Type, Effectiveness> entry : byType.entrySet()) {
+            Integer berry = Gen5Constants.weaknessReducingBerries.get(entry.getKey());
+            if (entry.getValue() == Effectiveness.DOUBLE) {
+                items.add(berry);
+            } else if (entry.getValue() == Effectiveness.QUADRUPLE) {
+                for (int i = 0; i < frequencyBoostCount; i++) {
+                    items.add(berry);
+                }
+            }
+        }
+        if (byType.get(Type.NORMAL) == Effectiveness.NEUTRAL) {
+            items.add(Gen4Constants.chilanBerry);
+        }
+        if (tp.ability == Abilities.levitate) {
+            items.removeAll(Arrays.asList(Gen4Constants.shucaBerry));
+        } else if (byType.get(Type.GROUND) == Effectiveness.DOUBLE || byType.get(Type.GROUND) == Effectiveness.QUADRUPLE) {
+            items.add(Gen5Constants.airBalloon);
+        }
+
+        if (!consumableOnly) {
+            if (Gen5Constants.abilityBoostingItems.containsKey(tp.ability)) {
+                items.addAll(Gen5Constants.abilityBoostingItems.get(tp.ability));
+            }
+            if (tp.pokemon.primaryType == Type.POISON || tp.pokemon.secondaryType == Type.POISON) {
+                items.add(Gen4Constants.blackSludge);
+            }
+            List<Integer> speciesItems = Gen5Constants.speciesBoostingItems.get(tp.pokemon.number);
+            if (speciesItems != null) {
+                for (int i = 0; i < frequencyBoostCount; i++) {
+                    items.addAll(speciesItems);
+                }
+            }
+            if (!tp.pokemon.evolutionsFrom.isEmpty() && tp.level >= 20) {
+                // eviolite can be too good for early game, so we gate it behind a minimum level.
+                // We go with the same level as the option for "No early wonder guard".
+                items.add(Gen5Constants.eviolite);
+            }
+        }
+        return items;
     }
 }

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen6RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen6RomHandler.java
@@ -24,10 +24,7 @@ package com.dabomstew.pkrandom.romhandlers;
 /*----------------------------------------------------------------------------*/
 
 import com.dabomstew.pkrandom.*;
-import com.dabomstew.pkrandom.constants.Gen5Constants;
-import com.dabomstew.pkrandom.constants.Gen6Constants;
-import com.dabomstew.pkrandom.constants.GlobalConstants;
-import com.dabomstew.pkrandom.constants.Species;
+import com.dabomstew.pkrandom.constants.*;
 import com.dabomstew.pkrandom.ctr.AMX;
 import com.dabomstew.pkrandom.ctr.GARCArchive;
 import com.dabomstew.pkrandom.ctr.Mini;
@@ -3505,5 +3502,90 @@ public class Gen6RomHandler extends Abstract3DSRomHandler {
     @Override
     public List<Integer> getAllConsumableHeldItems() {
         return Gen6Constants.consumableHeldItems;
+    }
+
+    @Override
+    public List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly, List<Move> moves, Map<Integer, List<MoveLearnt>> movesets) {
+        List<Integer> items = new ArrayList<>();
+        items.addAll(Gen6Constants.generalPurposeConsumableItems);
+        int frequencyBoostCount = 6; // Make some very good items more common, but not too common
+        if (!consumableOnly) {
+            frequencyBoostCount = 8; // bigger to account for larger item pool.
+            items.addAll(Gen6Constants.generalPurposeItems);
+        }
+        int[] pokeMoves = RomFunctions.getMovesAtLevel(tp.pokemon.number, movesets, tp.level);
+        int numDamagingMoves = 0;
+        for (int moveIdx : pokeMoves) {
+            Move move = moves.get(moveIdx);
+            if (move == null) {
+                continue;
+            }
+            if (move.category == MoveCategory.PHYSICAL) {
+                numDamagingMoves++;
+                items.add(Gen4Constants.liechiBerry);
+                items.add(Gen6Constants.consumableTypeBoostingItems.get(move.type));
+                if (!consumableOnly) {
+                    items.addAll(Gen6Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen4Constants.choiceBand);
+                    items.add(Gen4Constants.muscleBand);
+                }
+            }
+            if (move.category == MoveCategory.SPECIAL) {
+                numDamagingMoves++;
+                items.add(Gen4Constants.petayaBerry);
+                items.add(Gen6Constants.consumableTypeBoostingItems.get(move.type));
+                if (!consumableOnly) {
+                    items.addAll(Gen6Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen4Constants.wiseGlasses);
+                    items.add(Gen4Constants.choiceSpecs);
+                }
+            }
+            if (!consumableOnly && Gen6Constants.moveBoostingItems.containsKey(moveIdx)) {
+                items.addAll(Gen6Constants.moveBoostingItems.get(moveIdx));
+            }
+        }
+        if (numDamagingMoves >= 2) {
+            items.add(Gen6Constants.assaultVest);
+        }
+        Map<Type, Effectiveness> byType = Effectiveness.against(tp.pokemon.primaryType, tp.pokemon.secondaryType, 6);
+        for(Map.Entry<Type, Effectiveness> entry : byType.entrySet()) {
+            Integer berry = Gen6Constants.weaknessReducingBerries.get(entry.getKey());
+            if (entry.getValue() == Effectiveness.DOUBLE) {
+                items.add(berry);
+            } else if (entry.getValue() == Effectiveness.QUADRUPLE) {
+                for (int i = 0; i < frequencyBoostCount; i++) {
+                    items.add(berry);
+                }
+            }
+        }
+        if (byType.get(Type.NORMAL) == Effectiveness.NEUTRAL) {
+            items.add(Gen4Constants.chilanBerry);
+        }
+        if (tp.ability == Abilities.levitate) {
+            items.removeAll(Arrays.asList(Gen4Constants.shucaBerry));
+        } else if (byType.get(Type.GROUND) == Effectiveness.DOUBLE || byType.get(Type.GROUND) == Effectiveness.QUADRUPLE) {
+            items.add(Gen5Constants.airBalloon);
+        }
+
+        if (!consumableOnly) {
+            if (Gen6Constants.abilityBoostingItems.containsKey(tp.ability)) {
+                items.addAll(Gen6Constants.abilityBoostingItems.get(tp.ability));
+            }
+            if (tp.pokemon.primaryType == Type.POISON || tp.pokemon.secondaryType == Type.POISON) {
+                items.add(Gen4Constants.blackSludge);
+            }
+            List<Integer> speciesItems = Gen6Constants.speciesBoostingItems.get(tp.pokemon.number);
+            if (speciesItems != null) {
+                for (int i = 0; i < frequencyBoostCount; i++) {
+                    items.addAll(speciesItems);
+                }
+            }
+            if (!tp.pokemon.evolutionsFrom.isEmpty() && tp.level >= 20) {
+                // eviolite can be too good for early game, so we gate it behind a minimum level.
+                // We go with the same level as the option for "No early wonder guard".
+                items.add(Gen5Constants.eviolite);
+            }
+        }
+        return items;
     }
 }

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen7RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen7RomHandler.java
@@ -27,10 +27,7 @@ import com.dabomstew.pkrandom.FileFunctions;
 import com.dabomstew.pkrandom.MiscTweak;
 import com.dabomstew.pkrandom.RomFunctions;
 import com.dabomstew.pkrandom.Settings;
-import com.dabomstew.pkrandom.constants.Gen6Constants;
-import com.dabomstew.pkrandom.constants.Gen7Constants;
-import com.dabomstew.pkrandom.constants.GlobalConstants;
-import com.dabomstew.pkrandom.constants.Species;
+import com.dabomstew.pkrandom.constants.*;
 import com.dabomstew.pkrandom.ctr.BFLIM;
 import com.dabomstew.pkrandom.ctr.GARCArchive;
 import com.dabomstew.pkrandom.ctr.Mini;
@@ -3200,5 +3197,93 @@ public class Gen7RomHandler extends Abstract3DSRomHandler {
     @Override
     public List<Integer> getAllHeldItems() {
         return Gen7Constants.allHeldItems;
+    }
+
+    @Override
+    public List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly, List<Move> moves, Map<Integer, List<MoveLearnt>> movesets) {
+        List<Integer> items = new ArrayList<>();
+        items.addAll(Gen7Constants.generalPurposeConsumableItems);
+        int frequencyBoostCount = 6; // Make some very good items more common, but not too common
+        if (!consumableOnly) {
+            frequencyBoostCount = 8; // bigger to account for larger item pool.
+            items.addAll(Gen7Constants.generalPurposeItems);
+        }
+        int[] pokeMoves = RomFunctions.getMovesAtLevel(tp.pokemon.number, movesets, tp.level);
+        int numDamagingMoves = 0;
+        for (int moveIdx : pokeMoves) {
+            Move move = moves.get(moveIdx);
+            if (move == null) {
+                continue;
+            }
+            if (move.category == MoveCategory.PHYSICAL) {
+                numDamagingMoves++;
+                items.add(Gen4Constants.liechiBerry);
+                items.add(Gen7Constants.consumableTypeBoostingItems.get(move.type));
+                if (!consumableOnly) {
+                    items.addAll(Gen7Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen4Constants.choiceBand);
+                    items.add(Gen4Constants.muscleBand);
+                }
+            }
+            if (move.category == MoveCategory.SPECIAL) {
+                numDamagingMoves++;
+                items.add(Gen4Constants.petayaBerry);
+                items.add(Gen7Constants.consumableTypeBoostingItems.get(move.type));
+                if (!consumableOnly) {
+                    items.addAll(Gen7Constants.typeBoostingItems.get(move.type));
+                    items.add(Gen4Constants.wiseGlasses);
+                    items.add(Gen4Constants.choiceSpecs);
+                }
+            }
+            if (!consumableOnly && Gen7Constants.moveBoostingItems.containsKey(moveIdx)) {
+                items.addAll(Gen7Constants.moveBoostingItems.get(moveIdx));
+            }
+        }
+        if (numDamagingMoves >= 2) {
+            items.add(Gen6Constants.assaultVest);
+        }
+        Map<Type, Effectiveness> byType = Effectiveness.against(tp.pokemon.primaryType, tp.pokemon.secondaryType, 7);
+        for(Map.Entry<Type, Effectiveness> entry : byType.entrySet()) {
+            Integer berry = Gen7Constants.weaknessReducingBerries.get(entry.getKey());
+            if (entry.getValue() == Effectiveness.DOUBLE) {
+                items.add(berry);
+            } else if (entry.getValue() == Effectiveness.QUADRUPLE) {
+                for (int i = 0; i < frequencyBoostCount; i++) {
+                    items.add(berry);
+                }
+            }
+        }
+        if (byType.get(Type.NORMAL) == Effectiveness.NEUTRAL) {
+            items.add(Gen4Constants.chilanBerry);
+        }
+        if (tp.ability == Abilities.levitate) {
+            items.removeAll(Arrays.asList(Gen4Constants.shucaBerry));
+        } else if (byType.get(Type.GROUND) == Effectiveness.DOUBLE || byType.get(Type.GROUND) == Effectiveness.QUADRUPLE) {
+            items.add(Gen5Constants.airBalloon);
+        }
+        if (Gen7Constants.consumableAbilityBoostingItems.containsKey(tp.ability)) {
+            items.add(Gen7Constants.consumableAbilityBoostingItems.get(tp.ability));
+        }
+
+        if (!consumableOnly) {
+            if (Gen7Constants.abilityBoostingItems.containsKey(tp.ability)) {
+                items.addAll(Gen7Constants.abilityBoostingItems.get(tp.ability));
+            }
+            if (tp.pokemon.primaryType == Type.POISON || tp.pokemon.secondaryType == Type.POISON) {
+                items.add(Gen4Constants.blackSludge);
+            }
+            List<Integer> speciesItems = Gen7Constants.speciesBoostingItems.get(tp.pokemon.number);
+            if (speciesItems != null) {
+                for (int i = 0; i < frequencyBoostCount; i++) {
+                    items.addAll(speciesItems);
+                }
+            }
+            if (!tp.pokemon.evolutionsFrom.isEmpty() && tp.level >= 20) {
+                // eviolite can be too good for early game, so we gate it behind a minimum level.
+                // We go with the same level as the option for "No early wonder guard".
+                items.add(Gen5Constants.eviolite);
+            }
+        }
+        return items;
     }
 }

--- a/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
@@ -205,7 +205,7 @@ public interface RomHandler {
 
     void randomizeTrainerHeldItems(Settings settings);
 
-    List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly);
+    List<Integer> getSensibleHeldItemsFor(TrainerPokemon tp, boolean consumableOnly, List<Move> moves, Map<Integer, List<MoveLearnt>> movesets);
 
     List<Integer> getAllConsumableHeldItems();
 


### PR DESCRIPTION
This PR implements the sensible items logic for Gens 3+.

I chose not to add more methods to RomHandler and AbstractRomHandler (e.g. functions to get the various breakdowns of items) because that seemed like 1) a leaky abstraction and 2) would make the code pretty hard to follow.

I chose to make some items (e.g. species specific items, weakness-berries, type-boosting items if a pokemon knows more than 1 damaging move of that type) more common rather than everything the same rarity.

I also made a few choices around flameOrb and toxicOrb (e.g. give them to Pokemon with guts or Fling/Trick etc).

Let me know what y'all think of those choices as well as the implementations.