### PR TITLE
Replace AILevel with IVs in TrainerPokemon

### DIFF
--- a/src/com/dabomstew/pkrandom/pokemon/TrainerPokemon.java
+++ b/src/com/dabomstew/pkrandom/pokemon/TrainerPokemon.java
@@ -34,7 +34,6 @@ public class TrainerPokemon {
     public int move3;
     public int move4;
 
-    public int AILevel;
     public int heldItem = 0;
     public boolean hasMegaStone;
     public boolean hasZCrystal;
@@ -52,6 +51,13 @@ public class TrainerPokemon {
     public byte spdefEVs;
     public byte speedEVs;
     public int IVs;
+    // In gens 3-5, there is a byte or word that corresponds
+    // to the IVs a trainer's pokemon has. In X/Y, this byte
+    // also encodes some other information, possibly related
+    // to EV spread. Because of the unknown part in X/Y,
+    // we store the whole "strength byte" so we can
+    // write it unchanged when randomizing trainer pokemon.
+    public int strength;
     
     public boolean resetMoves = false;
 
@@ -86,7 +92,7 @@ public class TrainerPokemon {
         tpk.move3 = move3;
         tpk.move4 = move4;
 
-        tpk.AILevel = AILevel;
+        tpk.strength = strength;
         tpk.heldItem = heldItem;
         tpk.abilitySlot = abilitySlot;
         tpk.forme = forme;

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen3RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen3RomHandler.java
@@ -1562,7 +1562,7 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
                 // no moves, blocks of 8 bytes
                 for (int poke = 0; poke < newPokeCount; poke++) {
                     TrainerPokemon tp = pokes.next();
-                    writeWord(pointerToPokes + poke * 8, (tp.IVs * 255) / 31);
+                    writeWord(pointerToPokes + poke * 8, Math.min(255, 1 + (tp.IVs * 255) / 31));
                     writeWord(pointerToPokes + poke * 8 + 2, tp.level);
                     writeWord(pointerToPokes + poke * 8 + 4, pokedexToInternal[tp.pokemon.number]);
                     if (tr.pokemonHaveItems()) {

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen3RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen3RomHandler.java
@@ -1373,6 +1373,21 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
         List<Trainer> theTrainers = new ArrayList<>();
         List<String> tcnames = this.getTrainerClassNames();
         for (int i = 1; i < amount; i++) {
+            // Trainer entries are 40 bytes
+            // Team flags; 1 byte; 0x01 = custom moves, 0x02 = held item
+            // Class; 1 byte
+            // Encounter Music and gender; 1 byte
+            // Battle Sprite; 1 byte
+            // Name; 12 bytes; 0xff terminated
+            // Items; 2 bytes each, 4 item slots
+            // Battle Mode; 1 byte; 0 means single, 1 means double.
+            // 3 bytes not used
+            // AI Flags; 1 byte
+            // 3 bytes not used
+            // Number of pokemon in team; 1 byte
+            // 3 bytes not used
+            // Pointer to pokemon; 4 bytes
+            // https://github.com/pret/pokefirered/blob/3dce3407d5f9bca69d61b1cf1b314fb1e921d572/include/battle.h#L111
             int trOffset = baseOffset + i * entryLen;
             Trainer tr = new Trainer();
             tr.offset = trOffset;
@@ -1386,12 +1401,19 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
             tr.poketype = pokeDataType;
             tr.name = this.readVariableLengthString(trOffset + 4);
             tr.fullDisplayName = tcnames.get(trainerclass) + " " + tr.name;
-            // Pokemon data!
+            // Pokemon structure data is like
+            // IV IV LV SP SP
+            // (HI HI)
+            // (M1 M1 M2 M2 M3 M3 M4 M4)
+            // IV is a "difficulty" level between 0 and 255 to represent 0 to 31 IVs.
+            //     These IVs affect all attributes. For the vanilla games, the majority
+            //     of trainers have 0 IVs; Elite Four members will have 31 IVs.
+            // https://github.com/pret/pokeemerald/blob/6c38837b266c0dd36ccdd04559199282daa7a8a0/include/data.h#L22
             if (pokeDataType == 0) {
                 // blocks of 8 bytes
                 for (int poke = 0; poke < numPokes; poke++) {
                     TrainerPokemon thisPoke = new TrainerPokemon();
-                    thisPoke.AILevel = readWord(pointerToPokes + poke * 8);
+                    thisPoke.IVs = ((readWord(pointerToPokes + poke * 8) & 0xFF) * 31) / 255;
                     thisPoke.level = readWord(pointerToPokes + poke * 8 + 2);
                     thisPoke.pokemon = pokesInternal[readWord(pointerToPokes + poke * 8 + 4)];
                     tr.pokemon.add(thisPoke);
@@ -1400,7 +1422,7 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
                 // blocks of 8 bytes
                 for (int poke = 0; poke < numPokes; poke++) {
                     TrainerPokemon thisPoke = new TrainerPokemon();
-                    thisPoke.AILevel = readWord(pointerToPokes + poke * 8);
+                    thisPoke.IVs = ((readWord(pointerToPokes + poke * 8) & 0xFF) * 31) / 255;
                     thisPoke.level = readWord(pointerToPokes + poke * 8 + 2);
                     thisPoke.pokemon = pokesInternal[readWord(pointerToPokes + poke * 8 + 4)];
                     thisPoke.heldItem = readWord(pointerToPokes + poke * 8 + 6);
@@ -1410,7 +1432,7 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
                 // blocks of 16 bytes
                 for (int poke = 0; poke < numPokes; poke++) {
                     TrainerPokemon thisPoke = new TrainerPokemon();
-                    thisPoke.AILevel = readWord(pointerToPokes + poke * 16);
+                    thisPoke.IVs = ((readWord(pointerToPokes + poke * 16) & 0xFF) * 31) / 255;
                     thisPoke.level = readWord(pointerToPokes + poke * 16 + 2);
                     thisPoke.pokemon = pokesInternal[readWord(pointerToPokes + poke * 16 + 4)];
                     thisPoke.move1 = readWord(pointerToPokes + poke * 16 + 6);
@@ -1423,7 +1445,7 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
                 // blocks of 16 bytes
                 for (int poke = 0; poke < numPokes; poke++) {
                     TrainerPokemon thisPoke = new TrainerPokemon();
-                    thisPoke.AILevel = readWord(pointerToPokes + poke * 16);
+                    thisPoke.IVs = ((readWord(pointerToPokes + poke * 16) & 0xFF) * 31) / 255;
                     thisPoke.level = readWord(pointerToPokes + poke * 16 + 2);
                     thisPoke.pokemon = pokesInternal[readWord(pointerToPokes + poke * 16 + 4)];
                     thisPoke.heldItem = readWord(pointerToPokes + poke * 16 + 6);
@@ -1512,7 +1534,8 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
                 // custom moves, blocks of 16 bytes
                 for (int poke = 0; poke < newPokeCount; poke++) {
                     TrainerPokemon tp = pokes.next();
-                    writeWord(pointerToPokes + poke * 16, tp.AILevel);
+                    // Add 1 to offset integer division truncation
+                    writeWord(pointerToPokes + poke * 16, Math.min(255, 1 + (tp.IVs * 255) / 31));
                     writeWord(pointerToPokes + poke * 16 + 2, tp.level);
                     writeWord(pointerToPokes + poke * 16 + 4, pokedexToInternal[tp.pokemon.number]);
                     int movesStart;
@@ -1539,7 +1562,7 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
                 // no moves, blocks of 8 bytes
                 for (int poke = 0; poke < newPokeCount; poke++) {
                     TrainerPokemon tp = pokes.next();
-                    writeWord(pointerToPokes + poke * 8, tp.AILevel);
+                    writeWord(pointerToPokes + poke * 8, (tp.IVs * 255) / 31);
                     writeWord(pointerToPokes + poke * 8 + 2, tp.level);
                     writeWord(pointerToPokes + poke * 8 + 4, pokedexToInternal[tp.pokemon.number]);
                     if (tr.pokemonHaveItems()) {

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen4RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen4RomHandler.java
@@ -2168,6 +2168,16 @@ public class Gen4RomHandler extends AbstractDSRomHandler {
             List<String> tnames = this.getTrainerNames();
             int trainernum = trainers.files.size();
             for (int i = 1; i < trainernum; i++) {
+                // Trainer entries are 20 bytes
+                // Team flags; 1 byte; 0x01 = custom moves, 0x02 = held item
+                // Class; 1 byte
+                // 1 byte not used
+                // Number of pokemon in team; 1 byte
+                // Items; 2 bytes each, 4 item slots
+                // AI Flags; 2 byte
+                // 2 bytes not used
+                // Battle Mode; 1 byte; 0 means single, 1 means double.
+                // 3 bytes not used
                 byte[] trainer = trainers.files.get(i);
                 byte[] trpoke = trpokes.files.get(i);
                 Trainer tr = new Trainer();
@@ -2177,16 +2187,27 @@ public class Gen4RomHandler extends AbstractDSRomHandler {
                 int numPokes = trainer[3] & 0xFF;
                 int pokeOffs = 0;
                 tr.fullDisplayName = tclasses.get(tr.trainerclass) + " " + tnames.get(i - 1);
-                // printBA(trpoke);
                 for (int poke = 0; poke < numPokes; poke++) {
-                    int ailevel = trpoke[pokeOffs] & 0xFF;
+                    // Structure is
+                    // IV SB LV LV SP SP FRM FRM
+                    // (HI HI)
+                    // (M1 M1 M2 M2 M3 M3 M4 M4)
+                    // where SB = 0 0 Ab Ab 0 0 G G
+                    // IV is a "difficulty" level between 0 and 255 to represent 0 to 31 IVs.
+                    //     These IVs affect all attributes. For the vanilla games, the
+                    //     vast majority of trainers have 0 IVs; Elite Four members will
+                    //     have 30 IVs.
+                    // Ab Ab = ability number, 0 for first ability, 2 for second [HGSS only]
+                    // G G affect the gender somehow. 0 appears to mean "most common
+                    //     gender for the species".
+                    int difficulty = trpoke[pokeOffs] & 0xFF;
                     int level = trpoke[pokeOffs + 2] & 0xFF;
                     int species = (trpoke[pokeOffs + 4] & 0xFF) + ((trpoke[pokeOffs + 5] & 0x01) << 8);
                     int formnum = (trpoke[pokeOffs + 5] >> 2);
                     TrainerPokemon tpk = new TrainerPokemon();
                     tpk.level = level;
                     tpk.pokemon = pokes[species];
-                    tpk.AILevel = ailevel;
+                    tpk.IVs = (difficulty * 31) / 255;
                     int abilitySlot = (trpoke[pokeOffs + 1] >>> 4) & 0xF;
                     if (abilitySlot == 0) {
                         // All Gen 4 games represent the first ability as ability 0.
@@ -2301,8 +2322,9 @@ public class Gen4RomHandler extends AbstractDSRomHandler {
                         // All Gen 4 games represent the first ability as ability 0.
                         ability = 0;
                     }
-                    writeWord(trpoke, pokeOffs, tp.AILevel);
-                    writeWord(trpoke, pokeOffs + 1, ability);
+                    // Add 1 to offset integer division truncation
+                    int difficulty = Math.min(255, 1 + (tp.IVs * 255) / 31);
+                    writeWord(trpoke, pokeOffs, difficulty | ability << 8);
                     writeWord(trpoke, pokeOffs + 2, tp.level);
                     writeWord(trpoke, pokeOffs + 4, tp.pokemon.number);
                     trpoke[pokeOffs + 5] |= (tp.forme << 2);

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen7RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen7RomHandler.java
@@ -1489,7 +1489,6 @@ public class Gen7RomHandler extends Abstract3DSRomHandler {
                         }
                     }
                     tpk.pokemon = pokes[species];
-                    tpk.AILevel = trainerAILevel;
                     tpk.forme = formnum;
                     tpk.formeSuffix = Gen7Constants.getFormeSuffixByBaseForme(species,formnum);
                     tpk.absolutePokeNumber = absolutePokeNumByBaseForme


### PR DESCRIPTION
AILevel was a bit misleading, so this updates the variable name and plugs the data into the proper IVs field.

IVs were checked by setting up a fight against a level 100 pokemon with endeavor as the only move. This way, we could observe the HP of the trainer pokemon and derive the IVs given the known base stats.

Along the way, I figured out a few more of the trainer fields that may be useful in future features, so I documented what I found.

The only real snag is the difference in the "strength" or "IV" field in gen 6 between ORAS and X/Y. To account for the unknown purpose of the high 3 bits in X/Y, we add a field to the TrainerPokemon class to account for that.