### PR TITLE
Improve repeated trainer name handling

### DIFF
--- a/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
@@ -4000,6 +4000,8 @@ public abstract class AbstractRomHandler implements RomHandler {
         List<String>[] allTrainerNames = new List[] { new ArrayList<String>(), new ArrayList<String>() };
         Map<Integer, List<String>> trainerNamesByLength[] = new Map[] { new TreeMap<Integer, List<String>>(),
                 new TreeMap<Integer, List<String>>() };
+        
+        List<String> repeatedTrainerNames = Arrays.asList(new String[] { "GRUNT", "EXECUTIVE", "SHADOW", "ADMIN", "GOON", "EMPLOYEE" });
 
         // Read name lists
         for (String trainername : customNames.getTrainerNames()) {
@@ -4060,8 +4062,7 @@ public abstract class AbstractRomHandler implements RomHandler {
             int tnIndex = -1;
             for (String trainerName : currentTrainerNames) {
                 tnIndex++;
-                if (translation.containsKey(trainerName) && !trainerName.equalsIgnoreCase("GRUNT")
-                        && !trainerName.equalsIgnoreCase("EXECUTIVE")) {
+                if (translation.containsKey(trainerName) && !repeatedTrainerNames.contains(trainerName.toUpperCase())) {
                     // use an already picked translation
                     newTrainerNames.add(translation.get(trainerName));
                     totalLength += this.internalStringLength(translation.get(trainerName));


### PR DESCRIPTION
Some trainer names that repeat in certain scenarios no longer carry one name for each trainer that shares their normal name. This means Team Flare Admins or Aether Foundation Employees will not have "Bob" as their name for every single trainer; they are handled in the same way the names "Grunt" and "Executive" are currently being treated, where they should have more possible names across multiple trainers. This gives a little more life to randomized trainer names.