### PR TITLE
Prevent TM/HM compatibility log crash caused by blank attack names

### DIFF
--- a/src/com/dabomstew/pkrandom/Randomizer.java
+++ b/src/com/dabomstew/pkrandom/Randomizer.java
@@ -979,17 +979,20 @@ public class Randomizer {
             log.printf("%3d " + nameSpFormat, pkmn.number, pkmn.fullName() + " ");
 
             for (int i = 1; i < flags.length; i++) {
-
-                int moveNameLength = moveData.get(moveList.get(i - 1)).name.length();
+                String moveName = moveData.get(moveList.get(i - 1)).name;
+                if (moveName.length() == 0) {
+                    moveName = "(BLANK)";
+                }
+                int moveNameLength = moveName.length();
                 if (flags[i]) {
                     if (includeTMNumber) {
                         if (i <= tmCount) {
-                            log.printf("|TM%02d %" + moveNameLength + "s ", i, moveData.get(moveList.get(i - 1)).name);
+                            log.printf("|TM%02d %" + moveNameLength + "s ", i, moveName);
                         } else {
-                            log.printf("|HM%02d %" + moveNameLength + "s ", i-tmCount, moveData.get(moveList.get(i - 1)).name);
+                            log.printf("|HM%02d %" + moveNameLength + "s ", i-tmCount, moveName);
                         }
                     } else {
-                        log.printf("|%" + moveNameLength + "s ", moveData.get(moveList.get(i - 1)).name);
+                        log.printf("|%" + moveNameLength + "s ", moveName);
                     }
                 } else {
                     if (includeTMNumber) {


### PR DESCRIPTION
In the event that a move name is empty, the application crashes when generating a TM/HM compatibility log. This PR supplies a placeholder string to use when the name literal has a length of 0.

This is only caused by the "Vietnamese Crystal" bootleg as far as I'm aware, and honestly, attempting to write this with a straight face is difficult.

(I did not open an issue for this, because it's in practice just asking for a meme ROM to be accommodated, so I figured I should just do it myself.)