### PR TITLE
Fix "Vietnamese Crystal" pokedex/catch crash

### DIFF
--- a/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
@@ -2357,7 +2357,13 @@ public class Gen2RomHandler extends AbstractGBCRomHandler {
         int movesEvosStart = romEntry.getValue("PokemonMovesetsTableOffset");
         int movesEvosBank = bankOf(movesEvosStart);
         byte[] pointerTable = new byte[Gen2Constants.pokemonCount * 2];
-        int startOfNextBank = ((movesEvosStart / GBConstants.bankSize) + 1) * GBConstants.bankSize;
+        int startOfNextBank;
+        if (isVietCrystal) {
+            startOfNextBank = 0x43E00; // fix for pokedex crash
+        }
+        else {
+            startOfNextBank = ((movesEvosStart / GBConstants.bankSize) + 1) * GBConstants.bankSize;
+        }
         int dataBlockSize = startOfNextBank - (movesEvosStart + pointerTable.length);
         int dataBlockOffset = movesEvosStart + pointerTable.length;
         byte[] dataBlock = new byte[dataBlockSize];


### PR DESCRIPTION
While I'm fully aware that attempting to fix bugs in Vietnamese Crystal is a fool's errand, I think just about every randomizer of it I've seen or read about has had a problem where the game crashes upon catching a Pokemon or opening your Pokedex. There is some data at 0x43E00 in Vietnamese Crystal that is not present in Japanese Pokemon Crystal, which gets overwritten by `writeEvosAndMovesLearnt` (as it probably should be in any clean non-meme rom). This PR just adds a simple exception for the `isVietCrystal` case that leaves that data intact, which fixes the Pokedex/catching crash. (It's still Vietnamese Crystal at the end of the day and players shouldn't really expect much in terms of things working in a glitchy bootleg, but I think this makes it marginally more playable!)