### PR TITLE
Exclude unusable items from VC item rando

### DIFF
--- a/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
@@ -297,6 +297,11 @@ public class Gen2RomHandler extends AbstractGBCRomHandler {
         loadItemNames();
         allowedItems = Gen2Constants.allowedItems.copy();
         nonBadItems = Gen2Constants.nonBadItems.copy();
+        // VietCrystal: exclude Burn Heal, Carbos, and Elixir
+        // crashes your game if used, glitches out your inventory if carried
+        if (isVietCrystal) {
+            allowedItems.banSingles(10, 31, 65);
+        }
     }
 
     private static RomEntry checkRomEntry(byte[] rom) {

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
@@ -297,7 +297,7 @@ public class Gen2RomHandler extends AbstractGBCRomHandler {
         loadItemNames();
         allowedItems = Gen2Constants.allowedItems.copy();
         nonBadItems = Gen2Constants.nonBadItems.copy();
-        // VietCrystal: exclude Burn Heal, Carbos, and Elixir
+        // VietCrystal: exclude Burn Heal, Calcium, and Elixir
         // crashes your game if used, glitches out your inventory if carried
         if (isVietCrystal) {
             allowedItems.banSingles(10, 31, 65);


### PR DESCRIPTION
This is the last PR I'm going to make that bothers you guys with support for a 20 year old meme bootleg, I promise.

This PR removes Burn Heal, Carbos, and Elixir from the randomized item pool in Vietnamese Crystal only. These items if collected will cause the inventory screen to permanently break, and cause the game to crash if the player attempts to use or discard them. They're easy to avoid in the original bootleg if the player is warned and has some game knowledge, but that goes out the window with randomized items.

(`loadedrom()` doesn't feel like the best place for this code to live, but I disliked it less than I disliked changing `setupAllowedItems` to require a VietCrystal flag. Please feel free to request changes if there is somewhere better for this to be written)