### PR TITLE
remove game-crashing moves from viet crystal movepool

### DIFF
--- a/src/com/dabomstew/pkrandom/constants/Gen2Constants.java
+++ b/src/com/dabomstew/pkrandom/constants/Gen2Constants.java
@@ -88,6 +88,9 @@ public class Gen2Constants {
     public static final List<Integer> brokenMoves = Arrays.asList(
             Moves.sonicBoom, Moves.dragonRage, Moves.hornDrill, Moves.fissure, Moves.guillotine);
 
+    public static final List<Integer> illegalVietCrystalMoves = Arrays.asList(
+            Moves.protect, Moves.rest, Moves.spikeCannon);
+
     public static final int tmBlockOneIndex = 191, tmBlockOneSize = 4, tmBlockTwoIndex = 196, tmBlockTwoSize = 24,
             tmBlockThreeIndex = 221, tmBlockThreeSize = 22;
 

--- a/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
@@ -2651,6 +2651,7 @@ public abstract class AbstractRomHandler implements RomHandler {
         allBanned.addAll(hms);
         allBanned.addAll(this.getMovesBannedFromLevelup());
         allBanned.addAll(GlobalConstants.zMoves);
+        allBanned.addAll(this.getIllegalMoves());
 
         // Build sets of moves
         List<Move> validMoves = new ArrayList<>();
@@ -3508,6 +3509,7 @@ public abstract class AbstractRomHandler implements RomHandler {
         @SuppressWarnings("unchecked")
         List<Integer> banned = new ArrayList<Integer>(noBroken ? this.getGameBreakingMoves() : Collections.EMPTY_LIST);
         banned.addAll(getMovesBannedFromLevelup());
+        banned.addAll(this.getIllegalMoves());
         // field moves?
         List<Integer> fieldMoves = this.getFieldMoves();
         int preservedFieldMoveCount = 0;
@@ -3772,6 +3774,7 @@ public abstract class AbstractRomHandler implements RomHandler {
         @SuppressWarnings("unchecked")
         List<Integer> banned = new ArrayList<Integer>(noBroken ? this.getGameBreakingMoves() : Collections.EMPTY_LIST);
         banned.addAll(getMovesBannedFromLevelup());
+        banned.addAll(this.getIllegalMoves());
 
         // field moves?
         List<Integer> fieldMoves = this.getFieldMoves();
@@ -6299,6 +6302,11 @@ public abstract class AbstractRomHandler implements RomHandler {
     public List<Integer> getGameBreakingMoves() {
         // Sonicboom & Dragon Rage
         return Arrays.asList(49, 82);
+    }
+
+    @Override
+    public List<Integer> getIllegalMoves() {
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
@@ -2476,6 +2476,15 @@ public class Gen2RomHandler extends AbstractGBCRomHandler {
     }
 
     @Override
+    public List<Integer> getIllegalMoves() {
+        // 3 moves that crash the game when used by self or opponent
+        if (isVietCrystal) {
+            return Gen2Constants.illegalVietCrystalMoves;
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
     public List<Integer> getFieldMoves() {
         // cut, fly, surf, strength, flash,
         // dig, teleport, whirlpool, waterfall,

--- a/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/RomHandler.java
@@ -573,6 +573,8 @@ public interface RomHandler {
 
     List<Integer> getGameBreakingMoves();
 
+    List<Integer> getIllegalMoves();
+
     // includes game or gen-specific moves like Secret Power
     // but NOT healing moves (Softboiled, Milk Drink)
     List<Integer> getFieldMoves();


### PR DESCRIPTION
I said my last PR would be the last one I do for this nonsense, but I went back on that, so I apologize for my insolence. This PR adds a property to the abstract ROM handler that allows for any generation to specify game-specific or generation-specific moves which should never be used in move randomization pools, but which do not qualify for being globally banned cross-generation (so different from Struggle for instance). 

Vietnamese Crystal is the only game I can currently see having any reason to need this (the three moves in question will crash the game any time they are used by yourself or an opponent, and Spike Cannon in particular crashes the game if you so much as point to it in a menu), so I didn't like this implementation making any sort of change to the ROM handler, but I couldn't find a more contained-within-Gen-2 way to do it that wasn't really ugly. (Modifying `getMoves` for instance to exclude these three attacks crashes the logger.)