### PR TITLE
Fix Pickup Items settings loading

### DIFF
--- a/src/com/dabomstew/pkrandom/Settings.java
+++ b/src/com/dabomstew/pkrandom/Settings.java
@@ -566,8 +566,8 @@ public class Settings {
                 highestLevelOnlyGetsItemsForTrainerPokemon));
 
         // 49 pickup item randomization
-        out.write(makeByteSelected(pickupItemsMod == PickupItemsMod.UNCHANGED,
-                pickupItemsMod == PickupItemsMod.RANDOM, banBadRandomPickupItems));
+        out.write(makeByteSelected(pickupItemsMod == PickupItemsMod.RANDOM,
+                pickupItemsMod == PickupItemsMod.UNCHANGED, banBadRandomPickupItems));
 
         try {
             byte[] romName = this.romName.getBytes("US-ASCII");


### PR DESCRIPTION
I had noticed that loading a rnqs settings file or a rndp preset file inverted the selection of Pickup items from Unchanged to Random compared to how that setting was saved in the file. The settings need to be in this order in Pickup Item's makeByteSelected() because of the order they're in in restoreEnum() on line 849, if I'm understanding everything correctly?