### PR TITLE
Remove TwistedSpoon from Vietnamese Crystal item pool

### DIFF
--- a/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
+++ b/src/com/dabomstew/pkrandom/romhandlers/Gen2RomHandler.java
@@ -329,10 +329,10 @@ public class Gen2RomHandler extends AbstractGBCRomHandler {
         allowedItems = Gen2Constants.allowedItems.copy();
         nonBadItems = Gen2Constants.nonBadItems.copy();
         actualCRC32 = FileFunctions.getCRC32(rom);
-        // VietCrystal: exclude Burn Heal, Calcium, and Elixir
+        // VietCrystal: exclude Burn Heal, Calcium, TwistedSpoon, and Elixir
         // crashes your game if used, glitches out your inventory if carried
         if (isVietCrystal) {
-            allowedItems.banSingles(Gen2Items.burnHeal, Gen2Items.calcium, Gen2Items.elixer);
+            allowedItems.banSingles(Gen2Items.burnHeal, Gen2Items.calcium, Gen2Items.elixer, Gen2Items.TwistedSpoon);
         }
     }
 


### PR DESCRIPTION
Found a video of someone playing this where TwistedSpoon caused inventory problems like the other excluded items do. https://www.youtube.com/watch?v=NSdUsBtqDok

I must have missed this in the initial research I did into VC's items in 2011.