### PR TITLE
Added shebang to launcher_UNIX.sh

### DIFF
--- a/launcher/launcher_UNIX.sh
+++ b/launcher/launcher_UNIX.sh
@@ -1,2 +1,3 @@
+#!/bin/bash
 cd "$( dirname "$0" )"
 java -Xmx4608M -jar PokeRandoZX.jar please-use-the-launcher


### PR DESCRIPTION
A very small change to the unix launcher script. I'm just adding a shebang to the script.

If you launch the application via a terminal, it's going to work without much problems - bash is going to execute it via bash, sh and zsh via sh. However, trying to execute the script in other ways, for example as a service or by creating a desktop file, is not going to work as it doesn't know what interpreter to use. Right now, this would require manually editing the launch script or creating your own, both are feasible, but not great ways.

There is very little reason to not have a shebang in the launcher script. The only difference there is is that zsh users will no longer use /bin/sh as interpreter, but /bin/bash, however, it's safe to assume that anyone that tries to use this randomizer has a somewhat modern distro that ships with bash so there are no problems with this. Alternatively, you could change the shebang to /bin/sh, to be absolutely sure. Bash just offers nicer syntax in case the launch script becomes more flashed out at some point.

I'm well aware that this might be a tiny, for some maybe even an insignificant change, but not having to manually edit the launch script is a big thing in terms of accessibility for newer users that might just start out with linux, and there is literally no drawback to it.