### PR TITLE
Add java check to launcher

### DIFF
--- a/launcher/launcher_MAC.command
+++ b/launcher/launcher_MAC.command
@@ -1,7 +1,12 @@
 cd "$( dirname "$0" )"
 
-if ! command -v java > /dev/null 2>&1; then
-  echo "Java not installed."
+if ! type -p java > /dev/null 2>&1; then
+  echo "Java is not installed."
+  exit
+fi
+
+if [[ $(java --version) == *"32-Bit"* ]]; then
+  echo "Wrong Java version: Java 32-Bit instead of 64-Bit is installed."
   exit
 fi
 

--- a/launcher/launcher_MAC.command
+++ b/launcher/launcher_MAC.command
@@ -5,7 +5,7 @@ if ! type -p java > /dev/null 2>&1; then
   exit
 fi
 
-if [[ $(java --version) == *"32-Bit"* ]]; then
+if [[ ! $(java --version) == *"64-Bit"* ]]; then
   echo "Wrong Java version: Java 32-Bit instead of 64-Bit is installed."
   exit
 fi

--- a/launcher/launcher_MAC.command
+++ b/launcher/launcher_MAC.command
@@ -2,11 +2,17 @@ cd "$( dirname "$0" )"
 
 if ! type -p java > /dev/null 2>&1; then
   echo "Java is not installed."
+
+  echo "Press Enter to exit..."
+  read -s
   exit
 fi
 
 if [[ ! $(java --version) == *"64-Bit"* ]]; then
-  echo "Wrong Java version: Java 32-Bit instead of 64-Bit is installed."
+  echo "Wrong Java version: No Java or Java 32-Bit instead of 64-Bit is installed."
+
+  echo "Press Enter to exit..."
+  read -s
   exit
 fi
 

--- a/launcher/launcher_MAC.command
+++ b/launcher/launcher_MAC.command
@@ -1,4 +1,11 @@
 cd "$( dirname "$0" )"
+
+if ! command -v java > /dev/null 2>&1; then
+  echo "Java not installed."
+  exit
+fi
+
 java -Xmx4608M -jar PokeRandoZX.jar please-use-the-launcher
+
 echo "Press Enter to exit..."
 read -s

--- a/launcher/launcher_UNIX.sh
+++ b/launcher/launcher_UNIX.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
+
 cd "$( dirname "$0" )"
+
+if ! command -v java > /dev/null 2>&1; then
+  echo "Java not installed."
+  exit
+fi
+
 java -Xmx4608M -jar PokeRandoZX.jar please-use-the-launcher

--- a/launcher/launcher_UNIX.sh
+++ b/launcher/launcher_UNIX.sh
@@ -2,8 +2,13 @@
 
 cd "$( dirname "$0" )"
 
-if ! command -v java > /dev/null 2>&1; then
-  echo "Java not installed."
+if ! type -p java > /dev/null 2>&1; then
+  echo "Java is not installed."
+  exit
+fi
+
+if [[ $(java --version) == *"32-Bit"* ]]; then
+  echo "Wrong Java version: Java 32-Bit instead of 64-Bit is installed."
   exit
 fi
 

--- a/launcher/launcher_UNIX.sh
+++ b/launcher/launcher_UNIX.sh
@@ -7,7 +7,7 @@ if ! type -p java > /dev/null 2>&1; then
   exit
 fi
 
-if [[ $(java --version) == *"32-Bit"* ]]; then
+if [[ ! $(java --version) == *"64-Bit"* ]]; then
   echo "Wrong Java version: Java 32-Bit instead of 64-Bit is installed."
   exit
 fi

--- a/launcher/launcher_WINDOWS.bat
+++ b/launcher/launcher_WINDOWS.bat
@@ -4,7 +4,13 @@ cd /d "%~dp0"
 
 where java >nul 2>nul
 if %errorlevel%==1 (
-    @echo Java not found.
+    @echo Java is not installed.
+    exit
+)
+
+FOR /F "delims=" %i IN ('java -version') DO set java_version=%i
+if NOT "%java_version%"=="%java_version:32-Bit=%" (
+    @echo Wrong Java version: Java 32-Bit instead of 64-Bit is installed.
     exit
 )
 

--- a/launcher/launcher_WINDOWS.bat
+++ b/launcher/launcher_WINDOWS.bat
@@ -4,17 +4,20 @@ cd /d "%~dp0"
 
 where java >nul 2>nul
 if %errorlevel%==1 (
-    @echo Java is not installed.
-    exit
+    echo Java is not installed.
+
+    goto press_key_to_exit
 )
 
-FOR /F "delims=" %i IN ('java -version') DO set java_version=%i
-if "%java_version%"=="%java_version:64-Bit=%" (
-    @echo Wrong Java version: Java 32-Bit instead of 64-Bit is installed.
-    exit
+java -version 2>&1 | findstr /i "64-Bit" >nul
+if %errorlevel%==1 (
+    echo Wrong Java version: Java 32-Bit instead of 64-Bit is installed.
+
+    goto press_key_to_exit
 )
 
 java -Xmx4608M -jar PokeRandoZX.jar please-use-the-launcher
 
+:press_key_to_exit
 echo Press any key to exit...
 pause >nul

--- a/launcher/launcher_WINDOWS.bat
+++ b/launcher/launcher_WINDOWS.bat
@@ -1,6 +1,14 @@
 @echo off
 pushd "%~dp0"
 cd /d "%~dp0"
+
+where java >nul 2>nul
+if %errorlevel%==1 (
+    @echo Java not found.
+    exit
+)
+
 java -Xmx4608M -jar PokeRandoZX.jar please-use-the-launcher
+
 echo Press any key to exit...
 pause >nul

--- a/launcher/launcher_WINDOWS.bat
+++ b/launcher/launcher_WINDOWS.bat
@@ -9,7 +9,7 @@ if %errorlevel%==1 (
 )
 
 FOR /F "delims=" %i IN ('java -version') DO set java_version=%i
-if NOT "%java_version%"=="%java_version:32-Bit=%" (
+if "%java_version%"=="%java_version:64-Bit=%" (
     @echo Wrong Java version: Java 32-Bit instead of 64-Bit is installed.
     exit
 )


### PR DESCRIPTION
So issues like these won't happen: https://github.com/Ajarmar/universal-pokemon-randomizer-zx/issues/606

I also want to look into how to check whether java 32-bit is installed and report that as well, so issues like these https://github.com/Ajarmar/universal-pokemon-randomizer-zx/issues/615 https://github.com/Ajarmar/universal-pokemon-randomizer-zx/issues/608 happen less frequent. People just don't read the wiki that often.

I don't know whether the `launcher_MAC.command` syntax is correct and have no way to check right now. I just assumed it's bash as well.